### PR TITLE
refactor: Test tweaks, type hint fixes

### DIFF
--- a/hordelib/comfy.py
+++ b/hordelib/comfy.py
@@ -66,7 +66,7 @@ class Comfy:
                 ]
         return data
 
-    def _fix_node_names(self, data: dict, design: dict) -> dict[str, str]:
+    def _fix_node_names(self, data: dict, design: dict) -> dict:
         # We have a list of nodes, attempt to rename them to the "title" set
         # in the design file. These must be unique names.
         newnodes = {}
@@ -84,7 +84,7 @@ class Comfy:
         for node in newnodes.values():
             if "inputs" in node:
                 for _, input in node["inputs"].items():
-                    if type(input) is list:  # noqa: SIM102
+                    if type(input) is list:
                         if input and input[0] in renames:
                             input[0] = renames[input[0]]
         return newnodes
@@ -201,7 +201,7 @@ class Comfy:
         return inference.outputs
 
     # Run a pipeline that returns an image in pixel space
-    def run_image_pipeline(self, pipeline_name: str, params: dict) -> BytesIO | None:
+    def run_image_pipeline(self, pipeline_name: str, params: dict) -> list[dict] | None:
         # From the horde point of view, let us assume the output we are interested in
         # is always in a HordeImageOutput node named "output_image". This is an array of
         # dicts of the form:

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -24,6 +24,10 @@ class HordeCheckpointLoader:
     def load_checkpoint(self, ckpt_name, output_vae=True, output_clip=True):
         logger.info(horde_model_manager)
         logger.info(horde_model_manager.compvis)
+        if horde_model_manager.compvis is None:
+            logger.error("horde_model_manager.compvis appears to be missing!")
+            raise RuntimeError()  # XXX
+
         return horde_model_manager.compvis.loaded_models[ckpt_name]
 
 

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -6,12 +6,13 @@ from hordelib.comfy import Comfy
 
 class TestSetup:
     NUMBER_OF_PIPELINES = 2
+    comfy: Comfy
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         self.comfy = Comfy()
         yield
-        self.comfy = None
+        del self.comfy
 
     def test_load_pipelines(self):
         loaded = self.comfy._load_pipelines()

--- a/tests/test_horde.py
+++ b/tests/test_horde.py
@@ -121,6 +121,7 @@ class TestHordeInference:
         }
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
+        assert pil_image is not None
         pil_image.save("horde_text_to_image.png")
 
     def test_text_to_image_clip_skip_2(self):
@@ -145,4 +146,5 @@ class TestHordeInference:
         }
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
+        assert pil_image is not None
         pil_image.save("horde_text_to_image_clip_skip_2.png")

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -8,6 +8,8 @@ from hordelib.model_manager.hyper import ModelManager
 
 
 class TestInference:
+    comfy: Comfy
+
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         self.comfy = Comfy()
@@ -17,7 +19,7 @@ class TestInference:
         model_manager.load("Deliberate")
         set_horde_model_manager(model_manager)
         yield
-        self.comfy = None
+        del self.comfy
         del model_manager
 
     def test_unknown_pipeline(self):
@@ -40,8 +42,8 @@ class TestInference:
             "model_loader.ckpt_name": "Deliberate",
             "clip_skip.stop_at_clip_layer": -1,
         }
-        assert self.comfy is not None
         images = self.comfy.run_image_pipeline("stable_diffusion", params)
+        assert images is not None
 
         image = Image.open(images[0]["imagedata"])
         image.save("pipeline_stable_diffusion.png")
@@ -62,8 +64,8 @@ class TestInference:
             "model_loader.ckpt_name": "Deliberate",
             "clip_skip.stop_at_clip_layer": -2,
         }
-        assert self.comfy is not None
         images = self.comfy.run_image_pipeline("stable_diffusion", params)
+        assert images is not None
 
         image = Image.open(images[0]["imagedata"])
         image.save("pipeline_stable_diffusion_clip_skip_2.png")
@@ -96,6 +98,7 @@ class TestInference:
             "upscale_sampler.denoise": 0.5,
         }
         images = self.comfy.run_image_pipeline("stable_diffusion_hires_fix", params)
+        assert images is not None
 
         image = Image.open(images[0]["imagedata"])
         image.save("pipeline_stable_diffusion_hires_fix.png")

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -1,14 +1,18 @@
 # test_initialisation.py
+import importlib
 
 
 def test_find_comfyui():
     import hordelib.ComfyUI
 
     assert hordelib.ComfyUI is not None
-    # hordelib.ComfyUI.execution
+
+    executionLoader = importlib.find_loader("hordelib.ComfyUI.execution")
+    assert executionLoader is not None
 
 
 def test_instantiation():
     from hordelib.comfy import Comfy
 
     _ = Comfy()
+    assert isinstance(_, Comfy)


### PR DESCRIPTION
- Tweaks `setup_and_teardown` to be more friendly to python language servers/linting
- Tweaks a few test `asserts` for the same reason, and to have the test be more likely to fail on an assert rather than raw exception
- Fixes a couple incorrect/misleading type hints