### PR TITLE
refactor: 'ModelManager' rework, added 'WorkerSettings'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,5 @@ model.ckpt
 coverage.lcov
 *.png
 comfy-prompt.json
+
+.vscode

--- a/hordelib/__init__.py
+++ b/hordelib/__init__.py
@@ -2,28 +2,17 @@ import os
 import sys
 
 from hordelib import install
-from hordelib.model_manager.hyper import ModelManager
+from hordelib.config_path import set_system_path
 from hordelib.settings import WorkerSettings
 
 VERSION = "0.0.10"
 COMFYUI_VERSION = "1ed6cadf1292fa7607317a438777e6e37fe2709d"
 
-current_file_path = os.path.abspath(__file__)
-current_folder = os.path.dirname(current_file_path)
-comfypath = os.path.join(current_folder, "ComfyUI")
-sys.path.append(comfypath)  # noqa: E402
+set_system_path()
 
 installer = install.Installer()
 installer.install(COMFYUI_VERSION)
 
 
-horde_model_manager = None  # This needs
-
-
 class HordelibException(Exception):
     pass
-
-
-def set_horde_model_manager(mm: ModelManager):
-    global horde_model_manager
-    horde_model_manager = mm

--- a/hordelib/__init__.py
+++ b/hordelib/__init__.py
@@ -3,7 +3,7 @@ import sys
 
 from hordelib import install
 from hordelib.model_manager.hyper import ModelManager
-from hordelib.utils.switch import Switch
+from hordelib.settings import WorkerSettings
 
 VERSION = "0.0.10"
 COMFYUI_VERSION = "1ed6cadf1292fa7607317a438777e6e37fe2709d"
@@ -16,13 +16,6 @@ sys.path.append(comfypath)  # noqa: E402
 installer = install.Installer()
 installer.install(COMFYUI_VERSION)
 
-
-disable_xformers = Switch()
-disable_voodoo = Switch()
-enable_local_ray_temp = Switch()
-disable_progress = Switch()
-disable_download_progress = Switch()
-enable_ray_alternative = Switch()
 
 horde_model_manager = None  # This needs
 

--- a/hordelib/cache/cache.py
+++ b/hordelib/cache/cache.py
@@ -8,7 +8,7 @@ from loguru import logger
 from PIL import Image
 from tqdm import tqdm
 
-from hordelib import disable_progress
+from hordelib.settings import WorkerSettings
 
 if sys.version_info < (3, 9):  # XXX
     import importlib_resources
@@ -78,7 +78,9 @@ class Cache:
         :return: List of files
         """
         files = []
-        for file in tqdm(os.listdir(input_directory), disable=disable_progress.active):
+        for file in tqdm(
+            os.listdir(input_directory), disable=WorkerSettings.disable_progress.active
+        ):
             if os.path.splitext(file)[1] in extensions:
                 files.append(os.path.splitext(file)[0])
         return files
@@ -145,7 +147,7 @@ class Cache:
         """
         pil_hashes = []
         file_hashes = []
-        for file in tqdm(files_list, disable=disable_progress.active):
+        for file in tqdm(files_list, disable=WorkerSettings.disable_progress.active):
             for extension in extensions:
                 file = file + extension
                 file_path = os.path.join(input_directory, file)

--- a/hordelib/clip/bulk.py
+++ b/hordelib/clip/bulk.py
@@ -8,10 +8,10 @@ from loguru import logger
 from PIL import Image
 from tqdm import tqdm
 
-from hordelib import disable_progress
 from hordelib.cache import Cache
 from hordelib.clip.image import ImageEmbed
 from hordelib.model_manager.clip import ClipModelManager
+from hordelib.settings import WorkerSettings
 
 
 class BulkImageEmbedder:
@@ -57,5 +57,7 @@ class BulkImageEmbedder:
         logger.info(f"Found {len(directory_list)} files. Filtering...")
         filtered_list = self.cache_image.filter_list(directory_list)
         logger.info(f"Found {len(filtered_list)} files to embed.")
-        for image in tqdm(filtered_list, disable=disable_progress.active):
+        for image in tqdm(
+            filtered_list, disable=WorkerSettings.disable_progress.active
+        ):
             self.insert(image, input_directory)

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -13,7 +13,9 @@ from PIL import Image
 from hordelib.ComfyUI import execution
 
 
-class Comfy:
+class Comfy_Horde:
+    """Handles horde-specific behavior against ComfyUI."""
+
     # Lookup of ComfyUI standard nodes to hordelib custom nodes
     NODE_REPLACEMENTS = {
         "CheckpointLoaderSimple": "HordeCheckpointLoader",
@@ -59,9 +61,9 @@ class Comfy:
         # We have a list of nodes and each node has a class type, which we may want to change
         for nodename, node in data.items():
             if ("class_type" in node) and (
-                node["class_type"] in Comfy.NODE_REPLACEMENTS
+                node["class_type"] in Comfy_Horde.NODE_REPLACEMENTS
             ):
-                data[nodename]["class_type"] = Comfy.NODE_REPLACEMENTS[
+                data[nodename]["class_type"] = Comfy_Horde.NODE_REPLACEMENTS[
                     node["class_type"]
                 ]
         return data

--- a/hordelib/config_path.py
+++ b/hordelib/config_path.py
@@ -1,0 +1,9 @@
+import os
+import sys
+
+
+def set_system_path():
+    current_file_path = os.path.abspath(__file__)
+    current_folder = os.path.dirname(current_file_path)
+    comfypath = os.path.join(current_folder, "ComfyUI")
+    sys.path.append(comfypath)  # noqa: E402

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -89,8 +89,9 @@ class HordeLib:
         params["sampler.sampler_name"] = sampler
 
         # Clip skip inversion, comfy uses -1, -2, etc
-        if params.get("clip_skip.stop_at_clip_layer", 0) > 0:
-            params["clip_skip.stop_at_clip_layer"] = -params["clip_skip.stop_at_clip_layer"]
+        clip_skip_key = "clip_skip.stop_at_clip_layer"
+        if params.get(clip_skip_key, 0) > 0:
+            params[clip_skip_key] = -params[clip_skip_key]
 
         return params
 

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -4,7 +4,58 @@ import contextlib
 
 from PIL import Image
 
-from hordelib.comfy import Comfy
+from hordelib.comfy_horde import Comfy_Horde
+from hordelib.model_manager.hyper import ModelManager
+
+
+class SharedModelManager(ModelManager):
+    """Extends `hyper.ModelManager` to be a singleton. Call `.loadModelManagers() to init.`"""
+
+    _instance = None
+    manager: ModelManager | None = None
+
+    def __new__(
+        cls,
+        # aitemplate: bool = False,
+        blip: bool = False,
+        clip: bool = False,
+        codeformer: bool = False,
+        compvis: bool = False,
+        controlnet: bool = False,
+        diffusers: bool = False,
+        # esrgan: bool = False,
+        # gfpgan: bool = False,
+        safety_checker: bool = False,
+    ):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+
+        if cls.manager is None:
+            cls.manager = ModelManager()
+
+        return cls._instance
+
+    @classmethod
+    def loadModelManagers(
+        cls,
+        # aitemplate: bool = False,
+        blip: bool = False,
+        clip: bool = False,
+        codeformer: bool = False,
+        compvis: bool = False,
+        controlnet: bool = False,
+        diffusers: bool = False,
+        # esrgan: bool = False,
+        # gfpgan: bool = False,
+        safety_checker: bool = False,
+    ):
+        if cls.manager is None:
+            raise Exception()  # XXX
+
+        args_passed = locals().copy()
+        args_passed.pop("cls")
+
+        cls.manager.init_model_managers(**args_passed)
 
 
 class HordeLib:
@@ -96,7 +147,7 @@ class HordeLib:
         return params
 
     def text_to_image(self, payload: dict[str, str | None]) -> Image.Image | None:
-        generator = Comfy()
+        generator = Comfy_Horde()
         images = generator.run_image_pipeline(
             "stable_diffusion", self._parameter_remap(payload)
         )

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -13,9 +13,10 @@ from loguru import logger
 from tqdm import tqdm
 from transformers import logging
 
-# from nataili import disable_download_progress
-from hordelib import disable_download_progress
 from hordelib.cache import get_cache_directory
+
+# from nataili import disable_download_progress
+from hordelib.settings import WorkerSettings
 
 if sys.version_info < (3, 9):
     import importlib_resources
@@ -348,7 +349,7 @@ class BaseModelManager:
                 miniters=1,
                 desc=pbar_desc,
                 total=int(r.headers.get("content-length", 0)),
-                disable=disable_download_progress.active,
+                disable=WorkerSettings.disable_download_progress.active,
             ) as pbar:
                 for chunk in r.iter_content(chunk_size=16 * 1024):
                     if chunk:

--- a/hordelib/model_manager/compvis.py
+++ b/hordelib/model_manager/compvis.py
@@ -1,10 +1,10 @@
 import os
 import time
 
-import comfy
 from loguru import logger
 
 from hordelib.cache import get_cache_directory
+from hordelib.ComfyUI.comfy.sd import load_checkpoint_guess_config
 from hordelib.model_manager.base import BaseModelManager
 
 
@@ -41,7 +41,7 @@ class CompVisModelManager(BaseModelManager):
             embeddings_path = os.getenv("HORDE_MODEL_DIR_EMBEDDINGS", "./")
             ckpt_path = self.get_model_files(model_name)[0]["path"]
             ckpt_path = f"{self.path}/{ckpt_path}"
-            self.loaded_models[model_name] = comfy.sd.load_checkpoint_guess_config(
+            self.loaded_models[model_name] = load_checkpoint_guess_config(
                 ckpt_path,
                 output_vae=True,
                 output_clip=True,

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -1,13 +1,15 @@
 import safetensors.torch
 import torch
-
-# from nataili.model_manager.compvis import CompVisModelManager, DisableInitialization
 from loguru import logger
 from omegaconf import OmegaConf
 
 # from ldm.util import instantiate_from_config
 from hordelib.cache import get_cache_directory
 from hordelib.model_manager.base import BaseModelManager
+from hordelib.model_manager.torch_hijack import (
+    DisableInitialization,
+    instantiate_from_config,
+)
 
 
 class ControlNetModelManager(BaseModelManager):
@@ -49,7 +51,7 @@ class ControlNetModelManager(BaseModelManager):
             with DisableInitialization(disable_clip=True):
                 model = instantiate_from_config(config.model)
         except Exception:
-            pass
+            pass  # XXX
         full_name = f"{model_name}_{target_name}"
         logger.info(f"Loaded {full_name} ControlLDM")
         sd15_with_control_state_dict = self.control_nets[model_name]["state_dict"]

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -1,7 +1,44 @@
+from enum import Enum
+
 import torch
 from loguru import logger
 
+from hordelib.model_manager.aitemplate import AITemplateModelManager
+from hordelib.model_manager.base import BaseModelManager
+from hordelib.model_manager.blip import BlipModelManager
+from hordelib.model_manager.clip import ClipModelManager
+from hordelib.model_manager.codeformer import CodeFormerModelManager
+from hordelib.model_manager.compvis import CompVisModelManager
+from hordelib.model_manager.controlnet import ControlNetModelManager
+from hordelib.model_manager.diffusers import DiffusersModelManager
+
+# from hordelib.model_manager.esrgan import EsrganModelManager
+# from hordelib.model_manager.gfpgan import GfpganModelManager
+from hordelib.model_manager.safety_checker import SafetyCheckerModelManager
+
 # from worker.util.voodoo import initialise_voodoo
+
+
+class EsrganModelManager:  # XXX # FIXME
+    pass
+
+
+class GfpganModelManager:  # XXX # FIXME
+    pass
+
+
+MODEL_MANAGERS_TYPE_LOOKUP = {
+    "aitemplate": AITemplateModelManager,
+    "blip": BlipModelManager,
+    "clip": ClipModelManager,
+    "codeformer": CodeFormerModelManager,
+    "compvis": CompVisModelManager,
+    "controlnet": ControlNetModelManager,
+    "diffusers": DiffusersModelManager,
+    # "esrgan": EsrganModelManager,
+    # "gfpgan": GfpganModelManager,
+    "safety_checker": SafetyCheckerModelManager,
+}
 
 
 class ModelManager:
@@ -9,87 +46,59 @@ class ModelManager:
     Contains links to all the other MM classes
     """
 
+    aitemplate: AITemplateModelManager | None = None
+    blip: BlipModelManager | None = None
+    clip: ClipModelManager | None = None
+    codeformer: CodeFormerModelManager | None = None
+    compvis: CompVisModelManager | None = None
+    controlnet: ControlNetModelManager | None = None
+    diffusers: DiffusersModelManager | None = None
+    esrgan: EsrganModelManager | None = None
+    gfpgan: GfpganModelManager | None = None
+    safety_checker: SafetyCheckerModelManager | None = None
+
     def __init__(
         self,
-        aitemplate: bool = False,
-        blip: bool = False,
-        clip: bool = False,
-        compvis: bool = False,
-        diffusers: bool = False,
-        esrgan: bool = False,
-        gfpgan: bool = False,
-        safety_checker: bool = False,
-        codeformer: bool = False,
-        controlnet: bool = False,
     ):
         # logger.initialise_voodoo()
-        if aitemplate:
-            from hordelib.model_manager.aitemplate import AITemplateModelManager
-
-            self.aitemplate = AITemplateModelManager()
-        else:
-            self.aitemplate = None
-        if blip:
-            from hordelib.model_manager.blip import BlipModelManager
-
-            self.blip = BlipModelManager()
-        else:
-            self.blip = None
-        if clip:
-            from hordelib.model_manager.clip import ClipModelManager
-
-            self.clip = ClipModelManager()
-        else:
-            self.clip = None
-        if compvis:
-            from hordelib.model_manager.compvis import CompVisModelManager
-
-            self.compvis = CompVisModelManager()
-        else:
-            self.compvis = None
-        if diffusers:
-            from hordelib.model_manager.diffusers import DiffusersModelManager
-
-            self.diffusers = DiffusersModelManager()
-        else:
-            self.diffusers = None
-        if esrgan:
-            from hordelib.model_manager.esrgan import EsrganModelManager
-
-            self.esrgan = EsrganModelManager()
-        else:
-            self.esrgan = None
-        if gfpgan:
-            from hordelib.model_manager.gfpgan import GfpganModelManager
-
-            self.gfpgan = GfpganModelManager()
-        else:
-            self.gfpgan = None
-        if safety_checker:
-            from hordelib.model_manager.safety_checker import SafetyCheckerModelManager
-
-            self.safety_checker = SafetyCheckerModelManager()
-        else:
-            self.safety_checker = None
-        if codeformer:
-            from hordelib.model_manager.codeformer import CodeFormerModelManager
-
-            self.codeformer = CodeFormerModelManager()
-        else:
-            self.codeformer = None
-        if controlnet:
-            from hordelib.model_manager.controlnet import ControlNetModelManager
-
-            self.controlnet = ControlNetModelManager()
-        else:
-            self.controlnet = None
         self.cuda_available = torch.cuda.is_available()
         self.models = {}
         self.available_models = []
         self.loaded_models = {}
-        self.init()
 
-    def init(self):
+    def init_model_managers(  # XXX
+        self,
+        aitemplate: bool = False,
+        blip: bool = False,
+        clip: bool = False,
+        codeformer: bool = False,
+        compvis: bool = False,
+        controlnet: bool = False,
+        diffusers: bool = False,
+        # esrgan: bool = False,
+        # gfpgan: bool = False,
+        safety_checker: bool = False,
+    ):
+        args_passed: dict = locals().copy()
+        args_passed.pop("self")
+
+        allModelMangerTypeKeys = MODEL_MANAGERS_TYPE_LOOKUP.keys()
+        # e.g. `MODEL_MANAGERS_TYPE_LOOKUP["compvis"]`` returns type `CompVisModelManager`
+
+        for argName, argValue in args_passed.items():
+            if not (argName in allModelMangerTypeKeys and hasattr(self, argName)):
+                raise Exception()  # XXX
+            if not argValue:
+                continue
+
+            modelmanager = MODEL_MANAGERS_TYPE_LOOKUP[argName]
+            # at runtime modelmanager() will be CompVisModelManager(), ClipModelManager(), etc
+
+            setattr(self, argName, modelmanager())
+
+        self.refreshManagers()
+
+    def refreshManagers(self):
         """
         Initialize SuperModelManager's models and available_models from
         the models and available_models of the model types.
@@ -121,162 +130,69 @@ class ModelManager:
         Note: It is not appropriate to place `model_type.init()` in `init()`
         because individual model types are already initialized after being created
         i.e. if `model_type.init()` is placed in `self.init()`, the database will be
-        loaded twice.
+        loaded twice. # XXX rewrite
         """
-        model_types = [
-            self.aitemplate,
-            self.blip,
-            self.clip,
-            self.compvis,
-            self.diffusers,
-            self.esrgan,
-            self.gfpgan,
-            self.safety_checker,
-            self.codeformer,
-            self.controlnet,
-        ]
-        self.available_models = []  # reset available models
-        for model_type in model_types:
-            if model_type is not None:
-                model_type.init()
-                self.models.update(model_type.models)
-                self.available_models.extend(model_type.available_models)
+        model_managers = []
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_managers.append(getattr(self, model_manager_type))
 
-    def download_model(self, model_name):
-        if self.aitemplate is not None and model_name in self.aitemplate.models:
-            return self.aitemplate.download_model(model_name)
-        if self.blip is not None and model_name in self.blip.models:
-            return self.blip.download_model(model_name)
-        if self.clip is not None and model_name in self.clip.models:
-            return self.clip.download_model(model_name)
-        if self.codeformer is not None and model_name in self.codeformer.models:
-            return self.codeformer.download_model(model_name)
-        if self.compvis is not None and model_name in self.compvis.models:
-            return self.compvis.download_model(model_name)
-        if self.diffusers is not None and model_name in self.diffusers.models:
-            return self.diffusers.download_model(model_name)
-        if self.esrgan is not None and model_name in self.esrgan.models:
-            return self.esrgan.download_model(model_name)
-        if self.gfpgan is not None and model_name in self.gfpgan.models:
-            return self.gfpgan.download_model(model_name)
-        if self.safety_checker is not None and model_name in self.safety_checker.models:
-            return self.safety_checker.download_model(model_name)
-        if self.controlnet is not None and model_name in self.controlnet.models:
-            return self.controlnet.download_model(model_name)
+        self.available_models = []  # reset available models
+        for model_manager in model_managers:
+            if model_manager is not None:
+                model_manager.init()
+                self.models.update(model_manager.models)
+                self.available_models.extend(model_manager.available_models)
+
+    def download_model(self, model_name) -> bool | None:
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if model_name not in model_manager.models:
+                continue
+
+            return model_manager.download_model(model_name)
+        return None  # XXX
 
     def download_all(self):
-        if self.aitemplate is not None:
-            self.aitemplate.download_ait()
-        if self.blip is not None:
-            self.blip.download_all_models()
-        if self.clip is not None:
-            self.clip.download_all_models()
-        if self.codeformer is not None:
-            self.codeformer.download_all_models()
-        if self.compvis is not None:
-            self.compvis.download_all_models()
-        if self.diffusers is not None:
-            self.diffusers.download_all_models()
-        if self.esrgan is not None:
-            self.esrgan.download_all_models()
-        if self.gfpgan is not None:
-            self.gfpgan.download_all_models()
-        if self.safety_checker is not None:
-            self.safety_checker.download_all_models()
-        if self.controlnet is not None:
-            self.controlnet.download_all_models()
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if isinstance(model_manager, AITemplateModelManager):
+                model_manager.download_ait("cuda")  # XXX
+                continue
+
+            model_manager.download_all_models()
 
     def validate_model(self, model_name, skip_checksum=False):
-        if self.blip is not None and model_name in self.blip.models:
-            return self.blip.validate_model(model_name, skip_checksum)
-        if self.clip is not None and model_name in self.clip.models:
-            return self.clip.validate_model(model_name, skip_checksum)
-        if self.codeformer is not None and model_name in self.codeformer.models:
-            return self.codeformer.validate_model(model_name, skip_checksum)
-        if self.compvis is not None and model_name in self.compvis.models:
-            return self.compvis.validate_model(model_name, skip_checksum)
-        if self.diffusers is not None and model_name in self.diffusers.models:
-            return self.diffusers.validate_model(model_name, skip_checksum)
-        if self.esrgan is not None and model_name in self.esrgan.models:
-            return self.esrgan.validate_model(model_name, skip_checksum)
-        if self.gfpgan is not None and model_name in self.gfpgan.models:
-            return self.gfpgan.validate_model(model_name, skip_checksum)
-        if self.safety_checker is not None and model_name in self.safety_checker.models:
-            return self.safety_checker.validate_model(model_name, skip_checksum)
-        if self.controlnet is not None and model_name in self.controlnet.models:
-            return self.controlnet.validate_model(model_name, skip_checksum)
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if model_manager_type == "aitemplate":  # XXX
+                continue
+            if model_name in model_manager.models:
+                model_manager.validate_model(model_name, skip_checksum)
 
     def taint_models(self, models):
-        if self.aitemplate is not None and any(
-            model in self.aitemplate.models for model in models
-        ):
-            self.aitemplate.taint_models(models)
-        if self.blip is not None and any(model in self.blip.models for model in models):
-            self.blip.taint_models(models)
-        if self.clip is not None and any(model in self.clip.models for model in models):
-            self.clip.taint_models(models)
-        if self.codeformer is not None and any(
-            model in self.codeformer.models for model in models
-        ):
-            self.codeformer.taint_models(models)
-        if self.compvis is not None and any(
-            model in self.compvis.models for model in models
-        ):
-            self.compvis.taint_models(models)
-        if self.diffusers is not None and any(
-            model in self.diffusers.models for model in models
-        ):
-            self.diffusers.taint_models(models)
-        if self.esrgan is not None and any(
-            model in self.esrgan.models for model in models
-        ):
-            self.esrgan.taint_models(models)
-        if self.gfpgan is not None and any(
-            model in self.gfpgan.models for model in models
-        ):
-            self.gfpgan.taint_models(models)
-        if self.safety_checker is not None and any(
-            model in self.safety_checker.models for model in models
-        ):
-            self.safety_checker.taint_models(models)
-        if self.controlnet is not None and any(
-            model in self.controlnet.models for model in models
-        ):
-            self.controlnet.taint_models(models)
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if any(model in model_manager.models for model in models):
+                model_manager.taint_models(models)
 
-    def unload_model(self, model_name):
-        if self.aitemplate is not None and model_name in self.aitemplate.models:
-            self.aitemplate.unload_model(model_name)
-        if self.blip is not None and model_name in self.blip.models:
-            self.blip.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.clip is not None and model_name in self.clip.models:
-            self.clip.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.codeformer is not None and model_name in self.codeformer.models:
-            self.codeformer.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.compvis is not None and model_name in self.compvis.models:
-            self.compvis.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.diffusers is not None and model_name in self.diffusers.models:
-            self.diffusers.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.esrgan is not None and model_name in self.esrgan.models:
-            self.esrgan.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.gfpgan is not None and model_name in self.gfpgan.models:
-            self.gfpgan.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.safety_checker is not None and model_name in self.safety_checker.models:
-            self.safety_checker.unload_model(model_name)
-            del self.loaded_models[model_name]
-        if self.controlnet is not None and model_name in self.controlnet.models:
-            self.controlnet.unload_model(model_name)
-            del self.loaded_models[model_name]
-        # Also remove from super() model list
-        if model_name in self.loaded_models:
-            del self.loaded_models[model_name]
+    def unload_model(self, model_name) -> bool:
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+            model_manager: BaseModelManager = getattr(self, model_manager_type)
+            if model_manager is None:
+                continue
+            if model_name not in model_manager.models:
+                continue
+            model_unloaded = model_manager.unload_model(model_name)
+            return model_unloaded
+        return False
 
     def get_loaded_models_names(self, string=False):
         """
@@ -329,7 +245,7 @@ class ModelManager:
         gpu_id=0,
         cpu_only=False,
         voodoo=False,
-    ):
+    ):  # XXX # TODO
         """
         model_name: str. Name of the model to load. See available_models for a list of available models.
         half_precision: bool. If True, the model will be loaded in half precision.

--- a/hordelib/model_manager/torch_hijack.py
+++ b/hordelib/model_manager/torch_hijack.py
@@ -1,0 +1,176 @@
+import importlib
+import sys
+
+import open_clip
+import torch
+import transformers
+
+
+def instantiate_from_config(config):
+    if "target" not in config:
+        if config == "__is_first_stage__":
+            return None
+        elif config == "__is_unconditional__":
+            return None
+        raise KeyError("Expected key `target` to instantiate.")
+    return get_obj_from_str(config["target"])(**config.get("params", dict()))
+
+
+def get_obj_from_str(string, reload=False):
+    module, cls = string.rsplit(".", 1)
+    if reload:
+        module_imp = importlib.import_module(module)
+        importlib.reload(module_imp)
+    return getattr(importlib.import_module(module, package=None), cls)
+
+
+class DisableInitialization:
+    """
+    When an object of this class enters a `with` block, it starts:
+    - preventing torch's layer initialization functions from working
+    - changes CLIP and OpenCLIP to not download model weights
+    - changes CLIP to not check if there is a new version of a file you already have
+    When it leaves the block, it reverts everything to how it was before.
+    Use it like this:
+    ```
+    with DisableInitialization():
+        do_things()
+    ```
+    """
+
+    def __init__(self, disable_clip=True):
+        self.replaced = []
+        self.disable_clip = disable_clip
+
+    def replace(self, obj, field, func):
+        original = getattr(obj, field, None)
+        if original is None:
+            return None
+
+        self.replaced.append((obj, field, original))
+        setattr(obj, field, func)
+
+        return original
+
+    def __enter__(self):
+        def do_nothing(*args, **kwargs):
+            pass
+
+        def create_model_and_transforms_without_pretrained(
+            self, *args, pretrained=None, **kwargs
+        ):
+            return self.create_model_and_transforms(*args, pretrained=None, **kwargs)
+
+        def CLIPTextModel_from_pretrained(
+            self, pretrained_model_name_or_path, *model_args, **kwargs
+        ):
+            if sys.version_info != (3, 8, 10):
+                try:
+                    res = self.CLIPTextModel_from_pretrained(
+                        None,
+                        *model_args,
+                        config=pretrained_model_name_or_path,
+                        state_dict={},
+                        **kwargs,
+                    )
+                except Exception:  # XXX
+                    res = self.CLIPTextModel_from_pretrained(
+                        None, *model_args, **kwargs
+                    )
+            else:
+                res = self.CLIPTextModel_from_pretrained(None, *model_args, **kwargs)
+
+            res.name_or_path = pretrained_model_name_or_path
+            return res
+
+        def transformers_modeling_utils_load_pretrained_model(self, *args, **kwargs):
+            args = (
+                args[0:3] + ("/",) + args[4:]
+            )  # resolved_archive_file; must set it to something to prevent what seems to be a bug
+            return self.transformers_modeling_utils_load_pretrained_model(
+                *args, **kwargs
+            )
+
+        def transformers_utils_hub_get_file_from_cache(original, url, *args, **kwargs):
+            # this file is always 404, prevent making request # XXX
+            bad_url = "https://huggingface.co/openai/clip-vit-large-patch14/resolve/main/added_tokens.json"
+            if (
+                url == bad_url
+                or url == "openai/clip-vit-large-patch14"
+                and args[0] == "added_tokens.json"
+            ):
+                return None
+
+            try:
+                res = original(url, *args, local_files_only=True, **kwargs)
+                if res is None:
+                    res = original(url, *args, local_files_only=False, **kwargs)
+                return res
+            except Exception:  # XXX
+                return original(url, *args, local_files_only=False, **kwargs)
+
+        def transformers_utils_hub_get_from_cache(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_utils_hub_get_from_cache, url, *args, **kwargs
+            )
+
+        def transformers_tokenization_utils_base_cached_file(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_tokenization_utils_base_cached_file,
+                url,
+                *args,
+                **kwargs,
+            )
+
+        def transformers_configuration_utils_cached_file(
+            url, *args, local_files_only=False, **kwargs
+        ):
+            return transformers_utils_hub_get_file_from_cache(
+                self.transformers_configuration_utils_cached_file, url, *args, **kwargs
+            )
+
+        self.replace(torch.nn.init, "kaiming_uniform_", do_nothing)
+        self.replace(torch.nn.init, "_no_grad_normal_", do_nothing)
+        self.replace(torch.nn.init, "_no_grad_uniform_", do_nothing)
+
+        if self.disable_clip:
+            self.create_model_and_transforms = self.replace(
+                open_clip,
+                "create_model_and_transforms",
+                create_model_and_transforms_without_pretrained,
+            )
+            self.CLIPTextModel_from_pretrained = self.replace(
+                transformers.CLIPTextModel,
+                "from_pretrained",
+                CLIPTextModel_from_pretrained,
+            )
+            self.transformers_modeling_utils_load_pretrained_model = self.replace(
+                transformers.modeling_utils.PreTrainedModel,
+                "_load_pretrained_model",
+                transformers_modeling_utils_load_pretrained_model,
+            )
+            self.transformers_tokenization_utils_base_cached_file = self.replace(
+                transformers.tokenization_utils_base,
+                "cached_file",
+                transformers_tokenization_utils_base_cached_file,
+            )
+            self.transformers_configuration_utils_cached_file = self.replace(
+                transformers.configuration_utils,
+                "cached_file",
+                transformers_configuration_utils_cached_file,
+            )
+            self.transformers_utils_hub_get_from_cache = self.replace(
+                transformers.utils.hub,
+                "get_from_cache",
+                transformers_utils_hub_get_from_cache,
+            )
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for obj, field, original in self.replaced:
+            setattr(obj, field, original)
+
+        self.replaced.clear()

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -4,7 +4,7 @@
 
 from loguru import logger
 
-from hordelib import horde_model_manager
+from hordelib.horde import SharedModelManager
 
 
 class HordeCheckpointLoader:
@@ -22,13 +22,16 @@ class HordeCheckpointLoader:
     CATEGORY = "loaders"
 
     def load_checkpoint(self, ckpt_name, output_vae=True, output_clip=True):
-        logger.info(horde_model_manager)
-        logger.info(horde_model_manager.compvis)
-        if horde_model_manager.compvis is None:
-            logger.error("horde_model_manager.compvis appears to be missing!")
+        if SharedModelManager.manager is None:  # XXX
             raise RuntimeError()  # XXX
 
-        return horde_model_manager.compvis.loaded_models[ckpt_name]
+        logger.info(SharedModelManager.manager)
+        if SharedModelManager.manager.compvis is None:
+            logger.error("horde_model_manager.compvis appears to be missing!")
+            raise RuntimeError()  # XXX
+        logger.info(SharedModelManager.manager.compvis)
+
+        return SharedModelManager.manager.compvis.loaded_models[ckpt_name]
 
 
 NODE_CLASS_MAPPINGS = {"HordeCheckpointLoader": HordeCheckpointLoader}

--- a/hordelib/settings.py
+++ b/hordelib/settings.py
@@ -1,0 +1,18 @@
+from hordelib.utils.switch import Switch
+
+
+class WorkerSettings:
+    disable_xformers = Switch()
+    disable_voodoo = Switch()
+    enable_local_ray_temp = Switch()
+    disable_progress = Switch()
+    disable_download_progress = Switch()
+    enable_ray_alternative = Switch()
+
+    _instance = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+
+        return cls._instance

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ pillow
 loguru
 GitPython
 clip-anytorch
+diffusers
+omegaconf

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -1,16 +1,16 @@
 # test_setup.py
 import pytest
 
-from hordelib.comfy import Comfy
+from hordelib.comfy_horde import Comfy_Horde
 
 
 class TestSetup:
     NUMBER_OF_PIPELINES = 2
-    comfy: Comfy
+    comfy: Comfy_Horde
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        self.comfy = Comfy()
+        self.comfy = Comfy_Horde()
         yield
         del self.comfy
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,22 +2,20 @@
 import pytest
 from PIL import Image
 
-from hordelib import set_horde_model_manager
-from hordelib.comfy import Comfy
-from hordelib.model_manager.hyper import ModelManager
+from hordelib.comfy_horde import Comfy_Horde
+from hordelib.horde import SharedModelManager
 
 
 class TestInference:
-    comfy: Comfy
+    comfy: Comfy_Horde
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        self.comfy = Comfy()
-        model_manager = ModelManager(
-            compvis=True,
-        )
-        model_manager.load("Deliberate")
-        set_horde_model_manager(model_manager)
+        self.comfy = Comfy_Horde()
+        model_manager = SharedModelManager()
+        model_manager.loadModelManagers(compvis=True)
+        assert model_manager.manager is not None
+        model_manager.manager.load("Deliberate")
         yield
         del self.comfy
         del model_manager

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -1,18 +1,22 @@
 # test_initialisation.py
-import importlib
+import importlib.machinery
+import os
+import sys
+import types
 
 
 def test_find_comfyui():
-    import hordelib.ComfyUI
+    from hordelib.ComfyUI import execution
 
-    assert hordelib.ComfyUI is not None
-
-    executionLoader = importlib.find_loader("hordelib.ComfyUI.execution")
-    assert executionLoader is not None
+    assert hasattr(execution, "get_input_data")
 
 
 def test_instantiation():
-    from hordelib.comfy import Comfy
+    from hordelib.config_path import set_system_path
 
-    _ = Comfy()
-    assert isinstance(_, Comfy)
+    set_system_path()
+
+    from hordelib.comfy_horde import Comfy_Horde
+
+    _ = Comfy_Horde()
+    assert isinstance(_, Comfy_Horde)


### PR DESCRIPTION
- Moved all global settings to `WorkerSettings`, use anywhere as follows:
```python
from hordelib.settings import WorkerSettings
WorkerSettings.disable_voodoo.toggle(true)
WorkerSettings.disable_voodoo.active
```
- Added `SharedModelManager`, which extends `ModelManager`, wrapping it as a singleton.
- `hordelib\model_manager\hyper.py` has been substantially reworked, but `ModelManager`'s function signatures remain the same, except for `__init__`, which is now obsoleted by `SharedModelManager.loadModelManagers(...)`
- Laid the ground work for all other model manager types
  - All files import now
  - All managers (`ClipModelManager`, `ControlNetModelManager`, `safety_checker`) etc instantiate ok.
    - Test Coverage is needed to make sure they actually work - they have not been tested vigorously.
