### PR TITLE
refactor: ModelManager improvements, test adjustments

### DIFF
--- a/hordelib/__init__.py
+++ b/hordelib/__init__.py
@@ -1,6 +1,3 @@
-import os
-import sys
-
 from hordelib import install
 from hordelib.config_path import set_system_path
 from hordelib.settings import WorkerSettings

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -8,31 +8,13 @@ from hordelib.comfy_horde import Comfy_Horde
 from hordelib.model_manager.hyper import ModelManager
 
 
-class SharedModelManager(ModelManager):
-    """Extends `hyper.ModelManager` to be a singleton. Call `.loadModelManagers() to init.`"""
-
+class SharedModelManager:
     _instance = None
     manager: ModelManager | None = None
 
-    def __new__(
-        cls,
-        # aitemplate: bool = False,
-        blip: bool = False,
-        clip: bool = False,
-        codeformer: bool = False,
-        compvis: bool = False,
-        controlnet: bool = False,
-        diffusers: bool = False,
-        # esrgan: bool = False,
-        # gfpgan: bool = False,
-        safety_checker: bool = False,
-    ):
+    def __new__(cls):
         if cls._instance is None:
             cls._instance = super().__new__(cls)
-
-        if cls.manager is None:
-            cls.manager = ModelManager()
-
         return cls._instance
 
     @classmethod
@@ -50,7 +32,7 @@ class SharedModelManager(ModelManager):
         safety_checker: bool = False,
     ):
         if cls.manager is None:
-            raise Exception()  # XXX
+            cls.manager = ModelManager()
 
         args_passed = locals().copy()
         args_passed.pop("cls")

--- a/hordelib/install.py
+++ b/hordelib/install.py
@@ -10,7 +10,7 @@ class Installer:
     def __init__(self):
         self.ourdir = os.path.dirname(os.path.realpath(__file__))
 
-    def get_commit_hash(self):
+    def get_commit_hash(self) -> str:
         head_file = os.path.join(self.ourdir, "ComfyUI", ".git", "HEAD")
         if not os.path.exists(head_file):
             return "NOT FOUND"
@@ -44,7 +44,7 @@ class Installer:
             return None
         return (True, result.stdout)
 
-    def install(self, comfy_version) -> None:
+    def install(self, comfy_version: str) -> None:
         # Install if ComfyUI is missing completely
         if not os.path.exists(f"{self.ourdir}/ComfyUI"):
             self._run("git clone https://github.com/comfyanonymous/ComfyUI.git")

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -168,7 +168,7 @@ class BaseModelManager:
             self.available_models.remove(model_name)
             self.tainted_models.append(model_name)
 
-    def taint_models(self, models):
+    def taint_models(self, models) -> None:
         for model in models:
             self.taint_model(model)
 
@@ -305,6 +305,8 @@ class BaseModelManager:
         # If no hashes available, return True for now
         # THIS IS A SECURITY RISK, EVENTUALLY WE SHOULD RETURN FALSE
         # But currently not all models specify hashes
+        # XXX
+
         return True
 
     def check_file_available(self, file_path):

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -12,13 +12,13 @@ class TestInference:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         self.comfy = Comfy_Horde()
-        model_manager = SharedModelManager()
-        model_manager.loadModelManagers(compvis=True)
-        assert model_manager.manager is not None
-        model_manager.manager.load("Deliberate")
+        SharedModelManager.loadModelManagers(compvis=True)
+        assert SharedModelManager.manager is not None
+        SharedModelManager.manager.load("Deliberate")
         yield
         del self.comfy
-        del model_manager
+        SharedModelManager._instance = None
+        SharedModelManager.manager = None
 
     def test_unknown_pipeline(self):
         result = self.comfy.run_pipeline("non-existent-pipeline", {})

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -1,8 +1,4 @@
 # test_initialisation.py
-import importlib.machinery
-import os
-import sys
-import types
 
 
 def test_find_comfyui():
@@ -12,11 +8,13 @@ def test_find_comfyui():
 
 
 def test_instantiation():
-    from hordelib.config_path import set_system_path
-
-    set_system_path()
-
     from hordelib.comfy_horde import Comfy_Horde
 
     _ = Comfy_Horde()
     assert isinstance(_, Comfy_Horde)
+
+
+def test_path():  # XXX
+    from hordelib.config_path import set_system_path
+
+    set_system_path()


### PR DESCRIPTION
- Moved closer to previous `ModelManager` feature parity
  - Some incorrect code has been fixed, and a few general improvements have been made.
  - Several docstrings added to `hyper.py`.
  - Still missing quite a bit of test coverage.
  - Tests that do exist are admittedly lacking vigor.
- Tests got another pass to `setup_and_teardown()`.