### PR TITLE
refactor: Lint-catchable issues, Rename comfy_horde, fixes

### DIFF
--- a/hordelib/clip/bulk.py
+++ b/hordelib/clip/bulk.py
@@ -1,9 +1,7 @@
 import hashlib
-import os
 from concurrent.futures import ThreadPoolExecutor
-from typing import Literal, Union
+from typing import Literal
 
-import numpy as np
 from loguru import logger
 from PIL import Image
 from tqdm import tqdm

--- a/hordelib/clip/coca.py
+++ b/hordelib/clip/coca.py
@@ -1,5 +1,4 @@
 import os
-from typing import Union
 
 import open_clip
 from PIL import Image
@@ -12,14 +11,14 @@ class CoCa:
         self.device = device
         self.half_precision = half_precision
 
-    def __call__(self, input_image: Union[str, Image.Image]):
+    def __call__(self, input_image: str | Image.Image):
         if isinstance(input_image, str):
             if not os.path.exists(input_image):
                 raise ValueError(f"Image path {input_image} does not exist")
             try:
                 input_image = Image.open(input_image)
             except Exception as e:
-                raise ValueError(f"Could not open image {input_image}: {e}")
+                raise ValueError(f"Could not open image {input_image}") from e
 
         image = self.transform(input_image).unsqueeze(0).to(self.device)
         if self.half_precision:

--- a/hordelib/clip/image.py
+++ b/hordelib/clip/image.py
@@ -1,19 +1,13 @@
 import hashlib
-import os
-
-# threading
-import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
-from uuid import uuid4
 
 import numpy as np
 import torch
+from loguru import logger
 from PIL import Image
 
 from hordelib.cache import Cache
 from hordelib.utils.cast import autocast_cuda
-from loguru import logger
 
 
 class ImageEmbed:
@@ -93,10 +87,11 @@ class ImageEmbed:
             raise ValueError("Either image or filename must be set")
         if image is not None and filename is not None:
             raise ValueError("Only one of image or filename must be set")
-        if image is None:
-            pil_image = Image.open(f"{directory}/{filename}").convert("RGB")
-        else:
-            pil_image = image
+        pil_image = (
+            Image.open(f"{directory}/{filename}").convert("RGB")
+            if image is None
+            else image
+        )
         if image is None:
             file_hash = hashlib.sha256(
                 open(f"{directory}/{filename}", "rb").read()

--- a/hordelib/clip/interrogate.py
+++ b/hordelib/clip/interrogate.py
@@ -1,6 +1,5 @@
 import hashlib
 import os
-from typing import Dict, List, Union
 
 import numpy as np
 import torch
@@ -32,7 +31,7 @@ class Interrogator:
     def load(
         self,
         key: str,
-        text_array: List[str],
+        text_array: list[str],
         individual: bool = True,
         device: str = "cuda",
     ):
@@ -152,12 +151,7 @@ class Interrogator:
             similarity[text] = round(
                 self._similarity(image_features, text_features)[0][0].item(), 4
             )
-        return {
-            k: v
-            for k, v in sorted(
-                similarity.items(), key=lambda item: item[1], reverse=True
-            )
-        }
+        return dict(sorted(similarity.items(), key=lambda item: item[1], reverse=True))
 
     def rank(self, image_features, text_array, key, device, top_count=2):
         """
@@ -197,10 +191,10 @@ class Interrogator:
 
     def __call__(
         self,
-        image: Image.Image = None,
-        filename: str = None,
-        directory: str = None,
-        text_array: Union[List[str], Dict[str, List[str]], None] = None,
+        image: Image.Image | None = None,
+        filename: str | None = None,
+        directory: str | None = None,
+        text_array: list[str] | dict[str, list[str]] | None = None,
         similarity=False,
         rank=False,
         top_count=2,
@@ -242,7 +236,7 @@ class Interrogator:
         )
         if similarity and not rank:
             results = {}
-            for k in text_array.keys():
+            for k in text_array:
                 results[k] = self.similarity(
                     image_features, text_array[k], k, self.model["device"]
                 )
@@ -250,7 +244,7 @@ class Interrogator:
             return results
         elif rank and not similarity:
             results = {}
-            for k in text_array.keys():
+            for k in text_array:
                 results[k] = self.rank(
                     image_features, text_array[k], k, self.model["device"], top_count
                 )
@@ -258,13 +252,13 @@ class Interrogator:
             return results
         else:
             similarity = {}
-            for k in text_array.keys():
+            for k in text_array:
                 similarity[k] = self.similarity(
                     image_features, text_array[k], k, self.model["device"]
                 )
                 logger.debug(f"{k}: {similarity[k]}")
             rank = {}
-            for k in text_array.keys():
+            for k in text_array:
                 rank[k] = self.rank(
                     image_features, text_array[k], k, self.model["device"], top_count
                 )

--- a/hordelib/clip/text.py
+++ b/hordelib/clip/text.py
@@ -7,7 +7,6 @@ import torch
 
 from hordelib.cache import Cache
 from hordelib.utils.cast import autocast_cuda
-from loguru import logger
 
 
 class TextEmbed:
@@ -69,6 +68,7 @@ class TextEmbed:
         if filename:
             np.save(f"{self.cache.cache_dir}/{text_hash}", text_embed_array)
             self.cache.add_sqlite_row(filename, text_hash, text_hash)
-        else:
+            return None
+        else:  # XXX
             np.save(f"{self.cache.cache_dir}/{text_hash}", text_embed_array)
             self.cache.add_sqlite_row(text, text_hash, text_hash)

--- a/hordelib/config_path.py
+++ b/hordelib/config_path.py
@@ -2,17 +2,21 @@ import os
 import sys
 
 
-def get_hordelib_path():
+def get_hordelib_path() -> str:
     """Returns the path hordelib is installed in."""
     current_file_path = os.path.abspath(__file__)
     return os.path.dirname(current_file_path)
 
 
-def get_comfyui_path():
+def get_comfyui_path() -> str:
     """Returns the path to ComfyUI that hordelib installs and manages."""
     return os.path.join(get_hordelib_path(), "ComfyUI")
 
 
-def set_system_path():
+def set_system_path() -> None:
     """Adds ComfyUI to the python path, as it is not a proper library."""
     sys.path.append(get_comfyui_path())
+
+
+def is_comfy_path_set() -> bool:
+    return get_comfyui_path() in sys.path

--- a/hordelib/horde.py
+++ b/hordelib/horde.py
@@ -4,7 +4,7 @@ import contextlib
 
 from PIL import Image
 
-from hordelib.comfy_horde import Comfy_Horde
+from hordelib.pipeline import HordeComfyPipelineHandler
 from hordelib.model_manager.hyper import ModelManager
 
 
@@ -129,7 +129,7 @@ class HordeLib:
         return params
 
     def text_to_image(self, payload: dict[str, str | None]) -> Image.Image | None:
-        generator = Comfy_Horde()
+        generator = HordeComfyPipelineHandler()
         images = generator.run_image_pipeline(
             "stable_diffusion", self._parameter_remap(payload)
         )

--- a/hordelib/model_manager/aitemplate.py
+++ b/hordelib/model_manager/aitemplate.py
@@ -86,23 +86,23 @@ class AITemplateModelManager(BaseModelManager):
         """
         if cuda_arch == 89:
             return self.models[model_name]["config"]["sm89"]["download"]
-        elif cuda_arch >= 80 and cuda_arch < 89:
+        if cuda_arch >= 80 and cuda_arch < 89:
             return self.models[model_name]["config"]["sm80"]["download"]
-        elif cuda_arch == 75:
+        if cuda_arch == 75:
             return self.models[model_name]["config"]["sm75"]["download"]
-        else:
-            logger.warning("CUDA Compute Capability not supported")
-            return []
+
+        logger.warning("CUDA Compute Capability not supported")
+        return []
 
     def get_ait_workdir(self, cuda_arch, model_name="stable_diffusion"):
         if cuda_arch == 89:
             return f"./{self.models[model_name]['config']['sm89']['download'][0]['file_path']}/"
-        elif cuda_arch >= 80 and cuda_arch < 89:
+        if cuda_arch >= 80 and cuda_arch < 89:
             return f"./{self.models[model_name]['config']['sm80']['download'][0]['file_path']}/"
-        elif cuda_arch == 75:
+        if cuda_arch == 75:
             return f"./{self.models[model_name]['config']['sm75']['download'][0]['file_path']}/"
-        else:
-            raise ValueError("CUDA Compute Capability not supported")
+
+        raise ValueError("CUDA Compute Capability not supported")
 
     def load(
         self,

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -69,10 +69,10 @@ class BaseModelManager:
             models = response.json()
             return models
         except Exception as e:
-            logger.info_err(
+            logger.error(
                 "Model Reference", status=f"Download failed: {e}"
-            )  # logger.init_err
-            logger.info_warn("Model Reference", status="Local")  # logger.init_warn
+            )  # logger.info_err
+            logger.warning("Model Reference", status="Local")  # logger.init_warn
             return json.loads((self.models_path).read_text())
 
     def get_model(self, model_name):
@@ -394,7 +394,7 @@ class BaseModelManager:
                 )
                 input("")
                 continue
-            # TODO: simplify
+            # TODO: simplify # XXX
             if "file_content" in download[i]:
                 file_content = download[i]["file_content"]
                 logger.info(f"writing {file_content} to {file_path}")

--- a/hordelib/model_manager/clip.py
+++ b/hordelib/model_manager/clip.py
@@ -144,10 +144,11 @@ class ClipModelManager(BaseModelManager):
                 )
             else:
                 logger.error(f"Unknown model type: {self.models[model_name]['type']}")
-                return
+                return None
             logger.info(f"Loading {model_name}", status="Success")  # logger.init_ok
             toc = time.time()
             logger.info(
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None

--- a/hordelib/model_manager/compvis.py
+++ b/hordelib/model_manager/compvis.py
@@ -52,3 +52,4 @@ class CompVisModelManager(BaseModelManager):
                 f"{model_name}: {round(toc-tic,2)} seconds", status="Loaded"
             )  # logger.init_ok
             return True
+        return None

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -64,7 +64,7 @@ class ControlNetModelManager(BaseModelManager):
                     continue
                 p = sd15_with_control_state_dict[key]
                 key_name = f'model.diffusion_model.{key.replace("control_model.", "")}'
-                if key_name in input_state_dict.keys():
+                if key_name in input_state_dict:
                     # logger.info(f"merging {key_name} from input {key} from control")
                     p_new = p + input_state_dict[key_name].clone().cpu()
                 else:
@@ -75,7 +75,7 @@ class ControlNetModelManager(BaseModelManager):
             for key in keys:
                 p = sd15_with_control_state_dict[key]
                 key_name = f'model.diffusion_model.{key.replace("control_model.", "")}'
-                if key in input_state_dict.keys():
+                if key in input_state_dict:
                     # logger.info(f"merging {key_name} from input {key} from control")
                     p_new = p + input_state_dict[key_name].clone().cpu()
                 else:
@@ -83,7 +83,7 @@ class ControlNetModelManager(BaseModelManager):
                     p_new = p
                 final_state_dict[f"control_model.{key}"] = p_new
         # remove key "lvlb_weights"
-        if "lvlb_weights" in final_state_dict.keys():
+        if "lvlb_weights" in final_state_dict:
             final_state_dict.pop("lvlb_weights")
         logger.info("Finished merging control net state dict into target state dict")
         logger.info(f"Loading {full_name} state dict")
@@ -97,6 +97,7 @@ class ControlNetModelManager(BaseModelManager):
             "device": device,
             "half_precision": half_precision,
         }
+        return None
 
     def load_controlnet(
         self,

--- a/hordelib/model_manager/diffusers.py
+++ b/hordelib/model_manager/diffusers.py
@@ -66,6 +66,7 @@ class DiffusersModelManager(BaseModelManager):
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None
 
     def load_diffusers(
         self,

--- a/hordelib/model_manager/esrgan.py
+++ b/hordelib/model_manager/esrgan.py
@@ -62,6 +62,7 @@ class EsrganModelManager(BaseModelManager):
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None
 
     def load_esrgan(
         self,
@@ -126,7 +127,7 @@ class EsrganModelManager(BaseModelManager):
                 scale=4,
                 model_path=model_path,
                 model=RealESRGAN_models[self.models[model_name]["name"]],
-                half=True if half_precision else False,
+                half=bool(half_precision),
                 device=device,
                 gpu_id=gpu_id,
             )

--- a/hordelib/model_manager/gfpgan.py
+++ b/hordelib/model_manager/gfpgan.py
@@ -58,6 +58,7 @@ class GfpganModelManager(BaseModelManager):
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None
 
     def load_gfpgan(
         self,

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -128,7 +128,7 @@ class ModelManager:
     def reload_database(self) -> None:
         """Completely resets the `BaseModelManager` classes, and forces each to re-init."""
         model_managers: list[BaseModelManager] = []
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_managers.append(getattr(self, model_manager_type))
 
         self.available_models = []  # reset available models
@@ -147,7 +147,7 @@ class ModelManager:
         Returns:
             bool | None: The success of the download. If `None`, the model_name was not found.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_manager: BaseModelManager = getattr(self, model_manager_type)
             if model_manager is None:
                 continue
@@ -160,7 +160,7 @@ class ModelManager:
 
     def download_all(self) -> None:
         """Attempts to download all available models for all `BaseModelManager` types."""
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_manager: BaseModelManager = getattr(self, model_manager_type)
             if model_manager is None:
                 continue
@@ -183,7 +183,7 @@ class ModelManager:
         Returns:
             bool | None: The result of the validation. If `None`, the model was not found.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_manager: BaseModelManager = getattr(self, model_manager_type)
             if model_manager is None:
                 continue
@@ -200,7 +200,7 @@ class ModelManager:
         Args:
             models (list[str]): The list of models to mark.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_manager: BaseModelManager = getattr(self, model_manager_type)
             if model_manager is None:
                 continue
@@ -217,7 +217,7 @@ class ModelManager:
         Returns:
             bool | None: The result of the unloading. If `None`, the model was not found.
         """
-        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP.keys():
+        for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             model_manager: BaseModelManager = getattr(self, model_manager_type)
             if model_manager is None:
                 continue
@@ -241,24 +241,22 @@ class ModelManager:
             model_types = ["ckpt", "diffusers"]
         models_available = []
         for model_type in model_types:
-            if model_type == "ckpt":
-                if self.compvis is not None:
-                    for model in self.compvis.models:
-                        # We don't want to check the .yaml file as those exist in this repo instead
-                        model_files = [
-                            filename
-                            for filename in self.compvis.get_model_files(model)
-                            if not filename["path"].endswith(".yaml")
-                        ]
-                        if self.compvis.check_available(model_files):
-                            models_available.append(model)
-            if model_type == "diffusers":
-                if self.diffusers is not None:
-                    for model in self.diffusers.models:
-                        if self.diffusers.check_available(
-                            self.diffusers.get_model_files(model)
-                        ):
-                            models_available.append(model)
+            if model_type == "ckpt" and self.compvis is not None:
+                for model in self.compvis.models:
+                    # We don't want to check the .yaml file as those exist in this repo instead
+                    model_files = [
+                        filename
+                        for filename in self.compvis.get_model_files(model)
+                        if not filename["path"].endswith(".yaml")
+                    ]
+                    if self.compvis.check_available(model_files):
+                        models_available.append(model)
+            if model_type == "diffusers" and self.diffusers is not None:
+                for model in self.diffusers.models:
+                    if self.diffusers.check_available(
+                        self.diffusers.get_model_files(model)
+                    ):
+                        models_available.append(model)
         return models_available
 
     def count_available_models_by_types(

--- a/hordelib/model_manager/new.py
+++ b/hordelib/model_manager/new.py
@@ -59,6 +59,7 @@ class NewModelManager(BaseModelManager):
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None
 
     def load_new(
         self,

--- a/hordelib/model_manager/safety_checker.py
+++ b/hordelib/model_manager/safety_checker.py
@@ -62,6 +62,7 @@ class SafetyCheckerModelManager(BaseModelManager):
                 f"Loading {model_name}: Took {toc-tic} seconds", status="Success"
             )  # logger.init_ok
             return True
+        return None
 
     def load_safety_checker(
         self,

--- a/hordelib/model_manager/torch_hijack.py
+++ b/hordelib/model_manager/torch_hijack.py
@@ -1,3 +1,4 @@
+"""Contains some special handling when working with torch."""
 import importlib
 import sys
 
@@ -10,10 +11,10 @@ def instantiate_from_config(config):
     if "target" not in config:
         if config == "__is_first_stage__":
             return None
-        elif config == "__is_unconditional__":
+        if config == "__is_unconditional__":
             return None
         raise KeyError("Expected key `target` to instantiate.")
-    return get_obj_from_str(config["target"])(**config.get("params", dict()))
+    return get_obj_from_str(config["target"])(**config.get("params", {}))
 
 
 def get_obj_from_str(string, reload=False):

--- a/hordelib/pipeline.py
+++ b/hordelib/pipeline.py
@@ -13,8 +13,8 @@ from PIL import Image
 from hordelib.ComfyUI import execution
 
 
-class Comfy_Horde:
-    """Handles horde-specific behavior against ComfyUI."""
+class HordeComfyPipelineHandler:
+    """Handles horde-specific behavior against ComfyUI pipelines."""
 
     # Lookup of ComfyUI standard nodes to hordelib custom nodes
     NODE_REPLACEMENTS = {
@@ -61,11 +61,11 @@ class Comfy_Horde:
         # We have a list of nodes and each node has a class type, which we may want to change
         for nodename, node in data.items():
             if ("class_type" in node) and (
-                node["class_type"] in Comfy_Horde.NODE_REPLACEMENTS
+                node["class_type"] in HordeComfyPipelineHandler.NODE_REPLACEMENTS
             ):
-                data[nodename]["class_type"] = Comfy_Horde.NODE_REPLACEMENTS[
-                    node["class_type"]
-                ]
+                data[nodename][
+                    "class_type"
+                ] = HordeComfyPipelineHandler.NODE_REPLACEMENTS[node["class_type"]]
         return data
 
     def _fix_node_names(self, data: dict, design: dict) -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,3 +50,6 @@ exclude = '''
   | \.tox
 )/
 '''
+
+[tool.ruff]
+line-length = 100

--- a/tests/test_comfy.py
+++ b/tests/test_comfy.py
@@ -1,37 +1,37 @@
 # test_setup.py
 import pytest
 
-from hordelib.comfy_horde import Comfy_Horde
+from hordelib.pipeline import HordeComfyPipelineHandler
 
 
 class TestSetup:
     NUMBER_OF_PIPELINES = 2
-    comfy: Comfy_Horde
+    pipelineHandler: HordeComfyPipelineHandler
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        self.comfy = Comfy_Horde()
+        self.pipelineHandler = HordeComfyPipelineHandler()
         yield
-        del self.comfy
+        del self.pipelineHandler
 
     def test_load_pipelines(self):
-        loaded = self.comfy._load_pipelines()
+        loaded = self.pipelineHandler._load_pipelines()
         assert loaded == TestSetup.NUMBER_OF_PIPELINES
         # Check the built in pipelines
-        assert "stable_diffusion" in self.comfy.pipelines
-        assert "stable_diffusion_hires_fix" in self.comfy.pipelines
+        assert "stable_diffusion" in self.pipelineHandler.pipelines
+        assert "stable_diffusion_hires_fix" in self.pipelineHandler.pipelines
 
     def test_load_invalid_pipeline(self):
-        loaded = self.comfy._load_pipeline("no-such-pipeline")
+        loaded = self.pipelineHandler._load_pipeline("no-such-pipeline")
         assert loaded is None
 
     def test_load_invalid_node(self, capsys):
-        self.comfy._load_node("no-such-node")
+        self.pipelineHandler._load_node("no-such-node")
         captured = capsys.readouterr()
         assert "No such file or directory" in str(captured)
 
     def test_load_custom_nodes(self):
-        self.comfy._load_custom_nodes()
+        self.pipelineHandler._load_custom_nodes()
 
         # Look for our nodes in the ComfyUI nodes list
         from hordelib.ComfyUI import execution
@@ -53,7 +53,7 @@ class TestSetup:
             "c.inputs.d.f": True,
             "unknown.parameter": False,
         }
-        self.comfy._set(test_dict, **params)
+        self.pipelineHandler._set(test_dict, **params)
         assert test_dict["a"]["inputs"]["b"]
         assert test_dict["c"]["inputs"]["d"]["e"]
         assert test_dict["c"]["inputs"]["d"]["f"]
@@ -65,7 +65,7 @@ class TestSetup:
             "node2": {"no_class": "NoClassType"},
             "node3-should-be-replaced": {"class_type": "CheckpointLoaderSimple"},
         }
-        data = self.comfy._fix_pipeline_types(data)
+        data = self.pipelineHandler._fix_pipeline_types(data)
 
         assert data["node1"]["class_type"] == "ShouldNotBeReplaced"
         assert data["node2"]["no_class"] == "NoClassType"
@@ -109,7 +109,7 @@ class TestSetup:
                 {"id": 3, "no_title": "Node3"},
             ]
         }
-        data = self.comfy._fix_node_names(data, design)
+        data = self.pipelineHandler._fix_node_names(data, design)
 
         assert "Node1" in data
         assert data["Node1"]["inputs"]["input1"][0] == "Node2"

--- a/tests/test_horde.py
+++ b/tests/test_horde.py
@@ -4,6 +4,18 @@ import pytest
 from hordelib.horde import HordeLib, SharedModelManager
 
 
+class TestNodeModel:
+    def test_HordeCheckpointLoader(self):
+        from hordelib.nodes.node_model_loader import HordeCheckpointLoader
+
+        assert isinstance(HordeCheckpointLoader.INPUT_TYPES(), dict)
+        ckptLoader = HordeCheckpointLoader()
+        assert ckptLoader is not None
+        assert isinstance(ckptLoader.RETURN_TYPES, tuple)
+        assert isinstance(ckptLoader.FUNCTION, str)
+        assert isinstance(ckptLoader.CATEGORY, str)
+
+
 class TestSharedModelManager:
     horde = HordeLib()
     default_model_manager_args: dict
@@ -30,6 +42,11 @@ class TestSharedModelManager:
         del self.horde
         SharedModelManager._instance = None
         SharedModelManager.manager = None
+
+    def test_singleton(self):
+        instance_a = SharedModelManager()
+        instance_b = SharedModelManager()
+        assert instance_a is instance_b
 
     def test_compvis(self):
         from hordelib.model_manager.compvis import CompVisModelManager

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -1,8 +1,8 @@
 # test_inference.py
-import pytest
+import pytest  # noqa: I001
 from PIL import Image
-
 from hordelib.pipeline import HordeComfyPipelineHandler
+
 from hordelib.horde import SharedModelManager
 
 

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -2,26 +2,26 @@
 import pytest
 from PIL import Image
 
-from hordelib.comfy_horde import Comfy_Horde
+from hordelib.pipeline import HordeComfyPipelineHandler
 from hordelib.horde import SharedModelManager
 
 
 class TestInference:
-    comfy: Comfy_Horde
+    pipelineHandler: HordeComfyPipelineHandler
 
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
-        self.comfy = Comfy_Horde()
+        self.pipelineHandler = HordeComfyPipelineHandler()
         SharedModelManager.loadModelManagers(compvis=True)
         assert SharedModelManager.manager is not None
         SharedModelManager.manager.load("Deliberate")
         yield
-        del self.comfy
+        del self.pipelineHandler
         SharedModelManager._instance = None
         SharedModelManager.manager = None
 
     def test_unknown_pipeline(self):
-        result = self.comfy.run_pipeline("non-existent-pipeline", {})
+        result = self.pipelineHandler.run_pipeline("non-existent-pipeline", {})
         assert result is None
 
     def test_stable_diffusion_pipeline(self):
@@ -40,7 +40,7 @@ class TestInference:
             "model_loader.ckpt_name": "Deliberate",
             "clip_skip.stop_at_clip_layer": -1,
         }
-        images = self.comfy.run_image_pipeline("stable_diffusion", params)
+        images = self.pipelineHandler.run_image_pipeline("stable_diffusion", params)
         assert images is not None
 
         image = Image.open(images[0]["imagedata"])
@@ -62,7 +62,7 @@ class TestInference:
             "model_loader.ckpt_name": "Deliberate",
             "clip_skip.stop_at_clip_layer": -2,
         }
-        images = self.comfy.run_image_pipeline("stable_diffusion", params)
+        images = self.pipelineHandler.run_image_pipeline("stable_diffusion", params)
         assert images is not None
 
         image = Image.open(images[0]["imagedata"])
@@ -95,7 +95,9 @@ class TestInference:
             "upscale_sampler.scheduler": "simple",
             "upscale_sampler.denoise": 0.5,
         }
-        images = self.comfy.run_image_pipeline("stable_diffusion_hires_fix", params)
+        images = self.pipelineHandler.run_image_pipeline(
+            "stable_diffusion_hires_fix", params
+        )
         assert images is not None
 
         image = Image.open(images[0]["imagedata"])

--- a/tests/test_initialisation.py
+++ b/tests/test_initialisation.py
@@ -8,10 +8,10 @@ def test_find_comfyui():
 
 
 def test_instantiation():
-    from hordelib.comfy_horde import Comfy_Horde
+    from hordelib.pipeline import HordeComfyPipelineHandler
 
-    _ = Comfy_Horde()
-    assert isinstance(_, Comfy_Horde)
+    _ = HordeComfyPipelineHandler()
+    assert isinstance(_, HordeComfyPipelineHandler)
 
 
 def test_path():  # XXX

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+# test_utils.py
+
+
+class TestWorkerSettings:
+    def test_checkSwitch(self):
+        from hordelib.settings import WorkerSettings
+        from hordelib.utils import switch
+
+        assert isinstance(WorkerSettings.disable_download_progress, switch.Switch)
+
+        WorkerSettings.disable_download_progress.activate()
+        assert WorkerSettings.disable_download_progress.active is True
+        WorkerSettings.disable_download_progress.disable()
+        assert WorkerSettings.disable_download_progress.active is False
+        WorkerSettings.disable_download_progress.toggle(True)
+        assert WorkerSettings.disable_download_progress.active is True


### PR DESCRIPTION
- refactor: Renames class `comfy_horde` to `HordeComfyPipelineHandler`
- fix: Code smells in model managers
  - Most changes are making an implied call explicit
  - Certain other changes are non-trivial refactors
- fix: Bad call to old logger function
- fix: For devs using ruff, silence line length lint
- ci: More test coverage
- chore: add is_comfy_path_set to config_path.py