### PR TITLE
Optimized tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,7 @@ coverage.lcov
 images/pip*.png
 images/test.png
 images/hor*.png
+images/hor*.webp
 comfy-prompt*.json
 
 .vscode

--- a/hordelib/nodes/node_model_loader.py
+++ b/hordelib/nodes/node_model_loader.py
@@ -26,7 +26,6 @@ class HordeCheckpointLoader:
         output_vae=True,
         output_clip=True,
     ):
-
         logger.debug(f"Loading model {model_name} through our custom node")
 
         if model_manager.manager is None:

--- a/hordelib/nodes/node_upscale_model_loader.py
+++ b/hordelib/nodes/node_upscale_model_loader.py
@@ -17,7 +17,6 @@ class HordeUpscaleModelLoader:
     CATEGORY = "loaders"
 
     def load_model(self, model_name, model_manager):
-
         logger.debug(f"Loading model {model_name} through our custom node")
 
         if model_manager.manager is None:

--- a/tests/test_horde_inference.py
+++ b/tests/test_horde_inference.py
@@ -13,20 +13,19 @@ class TestHordeInference:
 
         self.default_model_manager_args = {
             # aitemplate
-            "blip": True,
-            "clip": True,
-            "codeformer": True,
+            # "blip": True,
+            # "clip": True,
+            # "codeformer": True,
             "compvis": True,
-            "controlnet": True,
-            "diffusers": True,
-            "esrgan": True,
-            "gfpgan": True,
-            "safety_checker": True,
+            # "controlnet": True,
+            # "diffusers": True,
+            # "esrgan": True,
+            # "gfpgan": True,
+            # "safety_checker": True,
         }
         SharedModelManager.loadModelManagers(**self.default_model_manager_args)
         assert SharedModelManager.manager is not None
         SharedModelManager.manager.load("Deliberate")
-        SharedModelManager.manager.load("RealESRGAN_x4plus")
         yield
         del self.horde
         SharedModelManager._instance = None
@@ -137,7 +136,7 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_text_to_image.png")
+        pil_image.save("images/horde_text_to_image.webp", quality=90)
 
     def test_text_to_image_small(self):
         data = {
@@ -162,7 +161,7 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_text_to_image_small.png")
+        pil_image.save("images/horde_text_to_image_small.webp", quality=90)
 
     def test_text_to_image_clip_skip_2(self):
         data = {
@@ -187,7 +186,7 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_text_to_image_clip_skip_2.png")
+        pil_image.save("images/horde_text_to_image_clip_skip_2.webp", quality=90)
 
     def test_text_to_image_hires_fix(self):
         data = {
@@ -212,7 +211,7 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_text_to_image_hires_fix.png")
+        pil_image.save("images/horde_text_to_image_hires_fix.webp", quality=90)
 
     def test_image_to_image(self):
         data = {
@@ -233,23 +232,13 @@ class TestHordeInference:
             "ddim_steps": 25,
             "n_iter": 1,
             "model": "Deliberate",
-            "source_image": Image.open("images/horde_text_to_image.png"),
+            "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_image_to_image.png")
-
-    def test_image_upscale(self):
-        data = {
-            "model": "RealESRGAN_x4plus",
-            "source_image": Image.open("images/horde_text_to_image_small.png"),
-        }
-        assert self.horde is not None
-        pil_image = self.horde.image_upscale(data)
-        assert pil_image is not None
-        pil_image.save("images/horde_image_upscale.png")
+        pil_image.save("images/horde_image_to_image.webp", quality=90)
 
     def test_image_to_image_hires_fix_small(self):
         data = {
@@ -270,13 +259,13 @@ class TestHordeInference:
             "ddim_steps": 25,
             "n_iter": 1,
             "model": "Deliberate",
-            "source_image": Image.open("images/horde_text_to_image.png"),
+            "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_image_to_image_hires_fix_small.png")
+        pil_image.save("images/horde_image_to_image_hires_fix_small.webp", quality=90)
 
     def test_image_to_image_hires_fix_large(self):
         data = {
@@ -297,15 +286,15 @@ class TestHordeInference:
             "ddim_steps": 25,
             "n_iter": 1,
             "model": "Deliberate",
-            "source_image": Image.open("images/horde_text_to_image.png"),
+            "source_image": Image.open("images/test_db0.jpg"),
             "source_processing": "img2img",
         }
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_image_to_image_hires_fix_large.png")
+        pil_image.save("images/horde_image_to_image_hires_fix_large.webp", quality=90)
 
-    def test_image_to_image_inpainting(self):
+    def test_image_to_image_mask_in(self):
         data = {
             "sampler_name": "k_dpmpp_2m",
             "cfg_scale": 7.5,
@@ -330,9 +319,9 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_image_to_image_inpainting.png")
+        pil_image.save("images/horde_image_to_image_mask_in.webp", quality=90)
 
-    def test_image_to_image_outpainting(self):
+    def test_image_to_image_mask_out(self):
         data = {
             "sampler_name": "euler",
             "cfg_scale": 8.0,
@@ -357,4 +346,4 @@ class TestHordeInference:
         assert self.horde is not None
         pil_image = self.horde.text_to_image(data)
         assert pil_image is not None
-        pil_image.save("images/horde_image_to_image_outpainting.png")
+        pil_image.save("images/horde_image_to_image_mask_out.webp", quality=90)

--- a/tests/test_horde_pp.py
+++ b/tests/test_horde_pp.py
@@ -1,11 +1,12 @@
 # test_horde.py
 import pytest
+from PIL import Image
 
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 
 
-class TestHordePostProcessing:
+class TestHordeUpscaling:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         self.horde = HordeLib()
@@ -19,19 +20,84 @@ class TestHordePostProcessing:
             # "controlnet": True,
             # "diffusers": True,
             "esrgan": True,
-            "gfpgan": True,
+            # "gfpgan": True,
             # "safety_checker": True,
         }
         SharedModelManager.loadModelManagers(**self.default_model_manager_args)
         assert SharedModelManager.manager is not None
-        SharedModelManager.manager.load("RealESRGAN_x4plus")
+        self.image = Image.open("images/test_db0.jpg")
         yield
         del self.horde
         SharedModelManager._instance = None
         SharedModelManager.manager = None
 
-    def test_load(self):
+    def test_image_upscale_RealESRGAN_x4plus(self):
+        SharedModelManager.manager.load("RealESRGAN_x4plus")
         assert (
             SharedModelManager.manager.esrgan.is_model_loaded("RealESRGAN_x4plus")
             is True
         )
+        data = {
+            "model": "RealESRGAN_x4plus",
+            "source_image": self.image,
+        }
+        assert self.horde is not None
+        pil_image = self.horde.image_upscale(data)
+        assert pil_image is not None
+        pil_image.save("images/horde_image_upscale_RealESRGAN_x4plus.webp", quality=90)
+
+    def test_image_upscale_RealESRGAN_x2plus(self):
+        SharedModelManager.manager.load("RealESRGAN_x2plus")
+        assert (
+            SharedModelManager.manager.esrgan.is_model_loaded("RealESRGAN_x2plus")
+            is True
+        )
+        data = {
+            "model": "RealESRGAN_x2plus",
+            "source_image": self.image,
+        }
+        pil_image = self.horde.image_upscale(data)
+        assert pil_image is not None
+        pil_image.save("images/horde_image_upscale_RealESRGAN_x2plus.webp", quality=90)
+
+    def test_image_upscale_NMKD_Siax(self):
+        SharedModelManager.manager.load("NMKD_Siax")
+        assert SharedModelManager.manager.esrgan.is_model_loaded("NMKD_Siax") is True
+        data = {
+            "model": "NMKD_Siax",
+            "source_image": self.image,
+        }
+        pil_image = self.horde.image_upscale(data)
+        assert pil_image is not None
+        pil_image.save("images/horde_image_upscale_NMKD_Siax.webp", quality=90)
+
+    def test_image_upscale_RealESRGAN_x4plus_anime_6B(self):
+        SharedModelManager.manager.load("RealESRGAN_x4plus_anime_6B")
+        assert (
+            SharedModelManager.manager.esrgan.is_model_loaded(
+                "RealESRGAN_x4plus_anime_6B"
+            )
+            is True
+        )
+        data = {
+            "model": "RealESRGAN_x4plus_anime_6B",
+            "source_image": self.image,
+        }
+        pil_image = self.horde.image_upscale(data)
+        assert pil_image is not None
+        pil_image.save(
+            "images/horde_image_upscale_RealESRGAN_x4plus_anime_6B.webp", quality=90
+        )
+
+    def test_image_upscale_4x_AnimeSharp(self):
+        SharedModelManager.manager.load("4x_AnimeSharp")
+        assert (
+            SharedModelManager.manager.esrgan.is_model_loaded("4x_AnimeSharp") is True
+        )
+        data = {
+            "model": "4x_AnimeSharp",
+            "source_image": self.image,
+        }
+        pil_image = self.horde.image_upscale(data)
+        assert pil_image is not None
+        pil_image.save("images/horde_image_upscale_4x_AnimeSharp.webp", quality=90)


### PR DESCRIPTION
Separated PP tests to their own file
Added test for each upscaler
Renamed inference test file
Made all images save as .webp
 (same as the Worker, and saves size)
Made inference avoid downloading all MM jsons all the time