### PR TITLE
refactor: Logger tweaks, Model Manager housekeeping

### DIFF
--- a/build_helper.py
+++ b/build_helper.py
@@ -1,9 +1,9 @@
 # build_helper.py
 # This is just a build helper script to build the pypi package.
+import argparse
 import os
 import shutil
 import subprocess
-import argparse
 
 from hordelib import install_comfy
 from hordelib.consts import COMFYUI_VERSION

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -550,10 +550,10 @@ class BaseModelManager(ABC):
         # XXX this has no fall back and always returns true
         for model in self.get_filtered_model_names(download_all=True):
             if not self.check_model_available(model):
-                logger.info(f"{model}", status="Downloading")  # logger.init
+                logger.init(f"{model}", status="Downloading")  # logger.init
                 self.download_model(model)
             else:
-                logger.info(f"{model} is already downloaded.")
+                logger.init(f"{model} is already downloaded.")
         return True
 
     def check_model_available(self, model_name: str) -> bool:

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -142,7 +142,7 @@ class BaseModelManager(ABC):
         model_name: str,
         *,
         half_precision: bool = True,
-        gpu_id: int | None = None,
+        gpu_id: int | None = 0,
         cpu_only: bool = False,
         **kwargs,
     ):  # XXX # FIXME

--- a/hordelib/model_manager/blip.py
+++ b/hordelib/model_manager/blip.py
@@ -1,5 +1,6 @@
 import importlib.resources as importlib_resources
 import time
+import typing
 from pathlib import Path
 
 import torch

--- a/hordelib/model_manager/blip.py
+++ b/hordelib/model_manager/blip.py
@@ -2,9 +2,11 @@ import importlib.resources as importlib_resources
 import time
 import typing
 from pathlib import Path
+import typing
 
 import torch
 from loguru import logger
+from typing_extensions import override
 
 from hordelib.config_path import get_hordelib_path
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
@@ -19,6 +21,7 @@ class BlipModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
+    @override
     def modelToRam(
         self,
         model_name,
@@ -26,7 +29,8 @@ class BlipModelManager(BaseModelManager):
         gpu_id=0,
         cpu_only=False,
         blip_image_eval_size=512,
-    ):
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         if not self.cuda_available:
             cpu_only = True
         vit = "base" if model_name == "BLIP" else "large"

--- a/hordelib/model_manager/blip.py
+++ b/hordelib/model_manager/blip.py
@@ -18,54 +18,6 @@ class BlipModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
-    def load(
-        self,
-        model_name: str,
-        half_precision=True,
-        gpu_id=0,
-        cpu_only=False,
-        blip_image_eval_size=512,
-    ):
-        """
-        model_name: str. Name of the model to load. See available_models for a list of available models.
-        half_precision: bool. If True, the model will be loaded in half precision.
-        gpu_id: int. The id of the gpu to use. If the gpu is not available, the model will be loaded on the cpu.
-        cpu_only: bool. If True, the model will be loaded on the cpu. If True, half_precision will be set to False.
-        blip_image_eval_size: int. The size of the image to use for the blip model.
-        """
-        if model_name not in self.model_reference:
-            logger.error(f"{model_name} not found")
-            return False
-        if model_name not in self.available_models:
-            logger.error(f"{model_name} not available")
-            logger.info(
-                f"Downloading {model_name}",
-                status="Downloading",
-            )  # logger.init_ok
-            self.download_model(model_name)
-            logger.info(
-                f"{model_name} downloaded",
-                status="Downloading",
-            )  # logger.init_ok
-        if model_name not in self.loaded_models:
-            tic = time.time()
-            logger.info(f"{model_name}", status="Loading")  # logger.init
-            self.loaded_models[model_name] = self.modelToRam(
-                model_name,
-                half_precision=half_precision,
-                gpu_id=gpu_id,
-                cpu_only=cpu_only,
-                blip_image_eval_size=blip_image_eval_size,
-            )
-            logger.info(f"Loading {model_name}", status="Success")  # logger.init_ok
-            toc = time.time()
-            logger.info(
-                f"Loading {model_name}: Took {toc-tic} seconds",
-                status="Success",
-            )  # logger.init_ok
-            return True
-        return None
-
     def modelToRam(
         self,
         model_name,

--- a/hordelib/model_manager/blip.py
+++ b/hordelib/model_manager/blip.py
@@ -2,7 +2,6 @@ import importlib.resources as importlib_resources
 import time
 import typing
 from pathlib import Path
-import typing
 
 import torch
 from loguru import logger

--- a/hordelib/model_manager/clip.py
+++ b/hordelib/model_manager/clip.py
@@ -1,10 +1,12 @@
 import time
+import typing
 from pathlib import Path
 
 import clip
 import open_clip
 import torch
 from loguru import logger
+from typing_extensions import override
 
 from hordelib.config_path import get_hordelib_path
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
@@ -106,13 +108,15 @@ class ClipModelManager(BaseModelManager):
             "cache_name": model_name.replace("/", "_"),
         }
 
+    @override
     def modelToRam(
         self,
         model_name: str,
         half_precision=True,
         gpu_id=0,
         cpu_only=False,
-    ):
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         """
         model_name: str. Name of the model to load. See available_models for a list of available models.
         half_precision: bool. If True, the model will be loaded in half precision.
@@ -152,10 +156,10 @@ class ClipModelManager(BaseModelManager):
             logger.error(
                 f"Unknown model type: {self.model_reference[model_name]['type']}",
             )
-            return None
+            return {}  # XXX # FIXME
         if not loaded_model_info:
             logger.init_error(f"Failed to load {model_name}", status="Error")
-            return None
+            return {}  # XXX # FIXME
 
         logger.init_ok(f"Loading {model_name}", status="Success")  # logger.init_ok
         toc = time.time()

--- a/hordelib/model_manager/clip.py
+++ b/hordelib/model_manager/clip.py
@@ -123,7 +123,7 @@ class ClipModelManager(BaseModelManager):
         if not self.cuda_available:
             cpu_only = True
         tic = time.time()
-        logger.info(f"{model_name}", status="Loading")  # logger.init
+        logger.init(f"{model_name}", status="Loading")  # logger.init
         if self.model_reference[model_name]["type"] == "open_clip":
             loaded_model_info = self.load_open_clip(
                 model_name,
@@ -157,9 +157,9 @@ class ClipModelManager(BaseModelManager):
             logger.init_error(f"Failed to load {model_name}", status="Error")
             return None
 
-        logger.info(f"Loading {model_name}", status="Success")  # logger.init_ok
+        logger.init_ok(f"Loading {model_name}", status="Success")  # logger.init_ok
         toc = time.time()
-        logger.info(
+        logger.init_ok(
             f"Loading {model_name}: Took {toc-tic} seconds",
             status="Success",
         )  # logger.init_ok

--- a/hordelib/model_manager/codeformer.py
+++ b/hordelib/model_manager/codeformer.py
@@ -1,6 +1,8 @@
 import time
+import typing
 
 from loguru import logger
+from typing_extensions import override
 
 from hordelib import comfy_horde
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
@@ -14,10 +16,12 @@ class CodeFormerModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
+    @override
     def modelToRam(
         self,
-        model_name,
-    ):
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         model_path = self.getFullModelPath(model_name)
         sd = comfy_horde.load_torch_file(model_path)
         out = comfy_horde.model_loading.load_state_dict(sd).eval()

--- a/hordelib/model_manager/compvis.py
+++ b/hordelib/model_manager/compvis.py
@@ -1,4 +1,7 @@
 import os
+import typing
+
+from typing_extensions import override
 
 from hordelib.comfy_horde import horde_load_checkpoint
 from hordelib.consts import (
@@ -21,7 +24,12 @@ class CompVisModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
-    def modelToRam(self, model_name: str):
+    @override
+    def modelToRam(
+        self,
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
 
         embeddings_path = os.getenv("HORDE_MODEL_DIR_EMBEDDINGS", "./")
 

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -1,6 +1,8 @@
 import os
+import typing
 
 from loguru import logger
+from typing_extensions import override
 
 from hordelib.comfy_horde import horde_load_controlnet
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
@@ -15,9 +17,14 @@ class ControlNetModelManager(BaseModelManager):
         )
         self.control_nets = {}
 
-    def modelToRam(self, model_name: str):
+    @override
+    def modelToRam(
+        self,
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         raise NotImplementedError(
-            "Controlnet requires special handling. Use `ControlNetModelManager.merge_controlnet(...)` instead of `load()`.",
+            "Controlnet requires special handling. Use `ControlNetModelManager.merge_controlnet(...)` instead of `ModelManager.load(...)`.",
         )  # XXX # TODO There might be way to avoid this.
 
     def merge_controlnet(
@@ -26,6 +33,7 @@ class ControlNetModelManager(BaseModelManager):
         model,
         model_baseline="stable diffusion 1",
     ):
+        # XXX would be nice to get the model name passed as a parameter
         controlnet_name = self.get_controlnet_name(control_type, model_baseline)
         if controlnet_name not in self.model_reference:
             logger.error(f"{controlnet_name} not found")

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -32,17 +32,17 @@ class ControlNetModelManager(BaseModelManager):
             return False
         if controlnet_name not in self.available_models:
             logger.error(f"{controlnet_name} not available")
-            logger.info(
+            logger.init_ok(
                 f"Downloading {controlnet_name}",
                 status="Downloading",
             )  # logger.init_ok
             self.download_control_type(control_type, [model_baseline])
-            logger.info(
+            logger.init_ok(
                 f"{controlnet_name} downloaded",
                 status="Downloading",
             )  # logger.init_ok
 
-        logger.info(f"{control_type}", status="Merging")  # logger.init
+        logger.init(f"{control_type}", status="Merging")  # logger.init
         controlnet_path = os.path.join(
             self.modelFolderPath,
             self.get_controlnet_filename(controlnet_name),

--- a/hordelib/model_manager/diffusers.py
+++ b/hordelib/model_manager/diffusers.py
@@ -1,3 +1,7 @@
+import typing
+
+from typing_extensions import override
+
 from hordelib.comfy_horde import horde_load_checkpoint
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
 from hordelib.model_manager.base import BaseModelManager
@@ -12,7 +16,12 @@ class DiffusersModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
-    def modelToRam(self, model_name: str, **kwargs):
+    @override
+    def modelToRam(
+        self,
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         return horde_load_checkpoint(
             ckpt_path=self.getFullModelPath(model_name),
         )

--- a/hordelib/model_manager/esrgan.py
+++ b/hordelib/model_manager/esrgan.py
@@ -1,3 +1,7 @@
+import typing
+
+from typing_extensions import override  # noqa: I001
+
 from hordelib import comfy_horde
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
 from hordelib.model_manager.base import BaseModelManager
@@ -10,10 +14,12 @@ class EsrganModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
+    @override
     def modelToRam(
         self,
-        model_name,
-    ):
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         model_path = self.getFullModelPath(model_name)
         sd = comfy_horde.load_torch_file(model_path)
         out = comfy_horde.model_loading.load_state_dict(sd).eval()

--- a/hordelib/model_manager/gfpgan.py
+++ b/hordelib/model_manager/gfpgan.py
@@ -1,3 +1,7 @@
+import typing
+
+from typing_extensions import override
+
 from hordelib import comfy_horde
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
 from hordelib.model_manager.base import BaseModelManager
@@ -10,10 +14,12 @@ class GfpganModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
+    @override
     def modelToRam(
         self,
-        model_name,
-    ):
+        model_name: str,
+        **kwargs,
+    ) -> dict[str, typing.Any]:
         model_path = self.getFullModelPath(model_name)
         sd = comfy_horde.load_torch_file(model_path)
         out = comfy_horde.model_loading.load_state_dict(sd).eval()

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -382,6 +382,7 @@ class ModelManager:
         if self.safety_checker is not None and model_name in self.safety_checker.model_reference:
             success = self.safety_checker.load(
                 model_name=model_name,
+                cpu_only=True,
             )
             if success:
                 self.loaded_models.update(

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -47,6 +47,7 @@ class ModelManager:
     esrgan: EsrganModelManager | None = None
     gfpgan: GfpganModelManager | None = None
     safety_checker: SafetyCheckerModelManager | None = None
+    # XXX I think this can be reworked into an array of BaseModelManager instances
 
     models: dict  # XXX unclear as to purpose... unused in AI-Horde-Worker?
     available_models: list
@@ -86,7 +87,9 @@ class ModelManager:
 
         for argName, argValue in args_passed.items():
             if not (argName in allModelMangerTypeKeys and hasattr(self, argName)):
-                raise Exception  # XXX better guarantees need to be made
+                raise Exception(
+                    f"{argName} is not a valid model manager type!",
+                )  # XXX better guarantees need to be made
             if not argValue:
                 continue
             if getattr(self, argName) is not None:

--- a/hordelib/model_manager/safety_checker.py
+++ b/hordelib/model_manager/safety_checker.py
@@ -5,6 +5,7 @@ from diffusers.pipelines.stable_diffusion.safety_checker import (
     StableDiffusionSafetyChecker,
 )
 from loguru import logger
+from typing_extensions import override
 
 from hordelib.consts import MODEL_CATEGORY_NAMES, MODEL_DB_NAMES
 from hordelib.model_manager.base import BaseModelManager
@@ -17,12 +18,14 @@ class SafetyCheckerModelManager(BaseModelManager):
             download_reference=download_reference,
         )
 
+    @override
     def modelToRam(
         self,
-        model_name,
+        model_name: str,
         half_precision=True,
         gpu_id=0,
-        cpu_only=True,  # XXX # FIXME These extra parameters are never able to be called from `load`
+        cpu_only=True,
+        **kwargs,
     ) -> dict[str, typing.Any]:
         if not self.cuda_available:
             cpu_only = True

--- a/hordelib/safety_checker.py
+++ b/hordelib/safety_checker.py
@@ -6,7 +6,7 @@ from hordelib.shared_model_manager import SharedModelManager
 
 def is_image_nsfw(image):
     if "safety_checker" not in SharedModelManager.manager.loaded_models:
-        SharedModelManager.manager.load("safety_checker")
+        SharedModelManager.manager.load("safety_checker", cpu_only=True)
     safety_checker_info = SharedModelManager.manager.loaded_models["safety_checker"]
     safety_checker = safety_checker_info["model"]
     feature_extractor = CLIPFeatureExtractor()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,9 @@ exclude = '''
 '''
 
 [tool.ruff] # XXX this isn't part of CI yet
-line-length=100 # XXX is this length settled on?
+line-length=119
 exclude=["comfy_controlnet_preprocessors", "facerestore"]
 ignore=[
-    "E501", # XXX line too long (comments are the big offender right now)
     "F401", # imported but unused
     "E402", # Module level import not at top of file
     "A002", # Argument `x` is shadowing a python builtin

--- a/tests/model_managers/test_safety_checker.py
+++ b/tests/model_managers/test_safety_checker.py
@@ -18,7 +18,7 @@ class TestSafetyChecker:
         del self.safety_model_manager
 
     def test_safety_checker_load_defaults(self):
-        success = self.safety_model_manager.load("safety_checker")
+        success = self.safety_model_manager.load("safety_checker", cpu_only=True)
         assert success
 
     # def test_safety_checker_load_cpu_only(self):

--- a/tests/test_safety_checker.py
+++ b/tests/test_safety_checker.py
@@ -35,7 +35,7 @@ class TestHordeSaftyChecker:
         SharedModelManager.manager = None
 
     def test_safety_checker_with_preload(self):
-        SharedModelManager.manager.load("safety_checker")
+        SharedModelManager.manager.load("safety_checker", cpu_only=True)
         assert SharedModelManager.manager.safety_checker.is_model_loaded("safety_checker") is True
         assert is_image_nsfw(self.image) is False
 


### PR DESCRIPTION
- Re-adds all custom logger methods in Model Managers.
- Another 'light' pass of housekeeping on the Model Managers.
- Fixes ruff to lint at 119 line length
- Adds and then removes a bug with cpu_only not being respected 