### PR TITLE
fix: Defer model manager loading

### DIFF
--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -44,6 +44,4 @@ def initialise(
     # Initialise model manager
     from hordelib.shared_model_manager import SharedModelManager
 
-    SharedModelManager.loadModelManagers(**model_managers_to_load)
-
     sys.argv = sys_arg_bkp


### PR DESCRIPTION
The loading of the model managers is best deferred, as it relies on environment variables being set.