### PR TITLE
fix: defer model manager loading

### DIFF
--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -44,6 +44,4 @@ def initialise(
     # Initialise model manager
     from hordelib.shared_model_manager import SharedModelManager
 
-    SharedModelManager.loadModelManagers(**model_managers_to_load)
-
     sys.argv = sys_arg_bkp


### PR DESCRIPTION
Removes the premature loading of the model managers from `hordelib.initialise()`.