### PR TITLE
refactor:  Add parent class to `OutputCollector`. Minor additional style/lint fixes.

### DIFF
--- a/examples/run_clip.py
+++ b/examples/run_clip.py
@@ -19,7 +19,7 @@ def main():
     from hordelib.horde import HordeLib
     from hordelib.shared_model_manager import SharedModelManager
 
-    generate = HordeLib()
+    HordeLib()
     SharedModelManager.loadModelManagers(clip=True, blip=True)
     SharedModelManager.manager.load("ViT-L/14")
     SharedModelManager.manager.load("BLIP_Large")
@@ -46,6 +46,7 @@ def main():
         repetition_penalty=1.4,
     )
     logger.warning(json.dumps(caption, indent=4))
+
 
 if __name__ == "__main__":
     main()

--- a/examples/run_memory_test.py
+++ b/examples/run_memory_test.py
@@ -27,7 +27,7 @@ def main():
     from hordelib.horde import HordeLib
     from hordelib.shared_model_manager import SharedModelManager
 
-    generate = HordeLib()
+    HordeLib()
     SharedModelManager.loadModelManagers(compvis=True)
 
     load_and_free()

--- a/hordelib/clip/bulk.py
+++ b/hordelib/clip/bulk.py
@@ -62,6 +62,6 @@ class BulkImageEmbedder:
         logger.info(f"Found {len(filtered_list)} files to embed.")
         for image in tqdm(
             filtered_list,
-            disable=UserSettings.disable_progress.active,
+            disable=UserSettings.disable_download_progress.active,
         ):
             self.insert(image, input_directory)

--- a/hordelib/clip/interrogate.py
+++ b/hordelib/clip/interrogate.py
@@ -200,9 +200,9 @@ class Interrogator:
 
     def __call__(
         self,
-        image: Image.Image = None,
-        filename: str = None,
-        directory: str = None,
+        image: Image.Image | None = None,
+        filename: str | None = None,
+        directory: str | None = None,
         text_array: list[str] | dict[str, list[str]] | None = None,
         similarity=False,
         rank=False,

--- a/hordelib/comfy_horde.py
+++ b/hordelib/comfy_horde.py
@@ -276,6 +276,7 @@ class Comfy_Horde:
                 return True
         except (OSError, ValueError):
             logger.error(f"Invalid inference pipeline file: {filename}")
+            return None
 
     def _load_pipelines(self) -> int:
         files = glob.glob(self._this_dir("pipeline_*.json", subdir="pipelines"))

--- a/hordelib/install_comfy.py
+++ b/hordelib/install_comfy.py
@@ -52,7 +52,7 @@ class Installer:
     def _run(cls, command, directory=get_hordelib_path()) -> tuple[bool, str] | None:
         # Don't if we're a release version
         if RELEASE_VERSION:
-            return
+            return None
         try:
             result = cls._run_get_result(command, directory)
         except Exception as Ex:

--- a/hordelib/model_manager/controlnet.py
+++ b/hordelib/model_manager/controlnet.py
@@ -15,7 +15,7 @@ class CONTROLNET_BASELINE_NAMES(str, Enum):  # XXX # TODO Move this to consts.py
     stable_diffusion_2 = "stable diffusion 2"
 
 
-CONTROLNET_BASELINE_APPENDS = {
+CONTROLNET_BASELINE_APPENDS: dict[CONTROLNET_BASELINE_NAMES | str, str] = {
     CONTROLNET_BASELINE_NAMES.stable_diffusion_1: "",
     CONTROLNET_BASELINE_NAMES.stable_diffusion_2: "_sd2",
 }
@@ -47,7 +47,7 @@ class ControlNetModelManager(BaseModelManager):
         control_type: str,
         model,
         model_baseline: str = CONTROLNET_BASELINE_NAMES.stable_diffusion_1,
-    ) -> tuple[any]:
+    ) -> tuple[typing.Any]:
         """Merge the specified control net with target model.
 
         Args:
@@ -95,7 +95,7 @@ class ControlNetModelManager(BaseModelManager):
     def download_control_type(
         self,
         control_type: str,
-        sd_baselines: list[str] = None,
+        sd_baselines: list[str] | None = None,
     ) -> None:
         if sd_baselines is None:
             sd_baselines = [CONTROLNET_BASELINE_NAMES.stable_diffusion_1, CONTROLNET_BASELINE_NAMES.stable_diffusion_2]
@@ -133,4 +133,5 @@ class ControlNetModelManager(BaseModelManager):
         for f in self.get_model_files(controlnet_name):
             if f["path"].endswith("safetensors"):
                 return f["path"]
+        logger.error(f"Could not find {controlnet_name}.safetensors on disk.")
         return None

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -52,7 +52,7 @@ class ModelManager:
     @property
     def models(self) -> dict:
         """All model manager's internal dictionaries of models, loaded from model database JSON files."""
-        _models = {}
+        _models: dict = {}
         for model_manager in self.active_model_managers:
             model_manager.model_reference
             _models.update(model_manager.model_reference)
@@ -75,7 +75,7 @@ class ModelManager:
         return all_loaded_models
 
     @property
-    def active_model_managers(self) -> list[BaseModelManager] | None:
+    def active_model_managers(self) -> list[BaseModelManager]:
         """All loaded model managers."""
         all_model_managers = [
             # self.aitemplate, # XXX TODO
@@ -291,7 +291,7 @@ class ModelManager:
         """
         return self.available_models
 
-    def ensure_memory_available(self, specific_type: type[BaseModelManager] = None) -> None:
+    def ensure_memory_available(self, specific_type: type[BaseModelManager] | None = None) -> None:
         """Asserts minimum amount of RAM is available. Unloads models if necessary."""
         for model_manager_type in MODEL_MANAGERS_TYPE_LOOKUP:
             if specific_type and specific_type != model_manager_type:

--- a/hordelib/settings.py
+++ b/hordelib/settings.py
@@ -1,10 +1,12 @@
+from typing_extensions import Self
+
 from hordelib.utils.switch import Switch
 
 
 class UserSettings:
     """Container class for all worker settings."""
 
-    _instance = None
+    _instance: Self | None = None
 
     def __new__(cls):
         if cls._instance is None:

--- a/hordelib/utils/ioredirect.py
+++ b/hordelib/utils/ioredirect.py
@@ -1,9 +1,10 @@
+import io
 from collections import deque
 
 from loguru import logger
 
 
-class OutputCollector:
+class OutputCollector(io.TextIOWrapper):
     def __init__(self):
         logger.disable("tqdm")  # just.. no
         self.deque = deque()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ exclude = '''
   | comfy_controlnet_preprocessors
   | facerestore
 )/
-'''
+''' # If you change this, you probably need to also change [tool.mypy] below
 
 [tool.ruff] # XXX this isn't part of CI yet
 line-length=119
@@ -117,3 +117,12 @@ select = [
 "med.py" = ["E501", "UP035"]
 "vit.py" = ["E501", "UP035", "F821"] # F821 looks like a real bug, suppressed only for dev CI purposes
 "run_stress_test.py" = ["F841"]
+
+
+[tool.mypy]
+exclude = '''(?x)(
+    ComfyUI
+  | \.tox
+  | comfy_controlnet_preprocessors
+  | facerestore
+)''' # If you change this, you probably need to also change [tool.black] above

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -3,3 +3,4 @@ black==22.3.0
 pytest>=7.2.2
 coverage>=7.2.3
 ruff==0.0.261
+build>=0.10.0


### PR DESCRIPTION
- `OutputCollector` now extends `io.TextIOWrapper`
  - This may or may not help maintainability with `OutputCollector`  as it was relying solely on duck-typing in a potentially fragile way from `contextlib`'s point of view.
- Minor additional style/lint fixes
- Adds `build` to `requirements.dev.txt`
- Updates `pyproject.toml` to support mypy, but there are no plans to enforce mypy rules (its use will be confined to helping spot code smells rather than make hordelib type safe).