### PR TITLE
fix: Tox lint/style environments now build (more) correctly

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,24 +38,27 @@ deps =
 
 [testenv:format]
 description = check formatting rules
+skip_install = true
+install_command = pip install
 deps =
     black==22.3.0
-skip_install = true
 commands = black --check .
 
 [testenv:lint]
 description = check all linting rules
+skip_install = true
+install_command = pip install
 deps =
     ruff==0.0.261
-skip_install = true
 commands = ruff .
 
 [testenv:lint-fix]
 description = fix all linting rules
+skip_install = true
+install_command = pip install
 deps =
     ruff==0.0.261
     black==22.3.0
-skip_install = true
 commands = 
     black .
     ruff --fix .
@@ -64,19 +67,21 @@ commands =
 
 [testenv:lint-weak-check]
 description = check only certain few linting rules
+skip_install = true
+install_command = pip install
 deps =
     ruff==0.0.261
-skip_install = true
 commands = 
     ruff --select COM,I .    
     python -c "print('*'*80 + '\n' + 'DEPRECATED: Favor using `tox -e lint` for checking for linting issues.\n' + '*'*80)"
 
 [testenv:lint-weak-fix]
 description = fixes only certain few linting rules
+skip_install = true
+install_command = pip install
 deps =
     black==22.3.0
     ruff==0.0.261
-skip_install = true
 commands = 
     black .
     ruff --fix --select COM,I .
@@ -92,6 +97,8 @@ commands =
 
 [testenv:tests]
 description = install pytest in a virtual environment and invoke it on the tests folder
+skip_install = false
+install_command = pip install {opts} {packages}
 passenv =
     HORDELIB_TESTING
     AIWORKER_CACHE_HOME


### PR DESCRIPTION
Corrects a mystery issue with tox, where the individual environments were not building as expected. It remains unclear as to the root cause.