### PR TITLE
build: add `build_helper.py` tox test, fix tox env mixups

### DIFF
--- a/.github/workflows/maintests.yml
+++ b/.github/workflows/maintests.yml
@@ -29,9 +29,13 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install tox and any other packages
         run: pip install --upgrade -r requirements.dev.txt
-      - name: Run lint/format check
+      - name: Run format check
+        run: tox -e format
+      - name: Run lint check
         run: tox -e lint-weak-check
-      - name: Run tox
+      - name: Check build_helper.py hordelib imports have no breaking dependency changes
+        run: tox -e test-build-helper
+      - name: Run unit tests
         run: tox -e tests
       - name: Run a direct run test
         run: python -m examples.run_upscale

--- a/.github/workflows/prtests.yml
+++ b/.github/workflows/prtests.yml
@@ -34,9 +34,13 @@ jobs:
           python-version: ${{ matrix.python }}
       - name: Install tox and any other packages
         run: pip install --upgrade -r requirements.dev.txt
-      - name: Run lint/format check
+      - name: Run format check
+        run: tox -e format
+      - name: Run lint check
         run: tox -e lint-weak-check
-      - name: Run tox
+      - name: Check build_helper.py hordelib imports have no breaking dependency changes
+        run: tox -e test-build-helper
+      - name: Run unit tests
         run: tox -e tests
       - name: Run a direct run test
         run: python -m examples.run_upscale

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,12 @@ jobs:
         python-version: "3.10"
 
     # Install build deps
+    # NOTE If `run` is changed, please also update `[testenv:test-build-helper]` in tox.ini
     - name: "🛠 Install pypa/build"
       if: ${{ steps.release.outputs.version != '' }}
       run: >-
         python -m pip install build typing-extensions loguru --user
+        
 
     - name: "✏️ Install changelog dependencies"
       if: ${{ steps.release.outputs.version != '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,9 @@ jobs:
         python-version: "3.10"
 
     # Install build deps
-    # NOTE If `run` is changed, please also update `[testenv:test-build-helper]` in tox.ini
+    # NOTE If any hordelib imports used by build_helper.py are changed, or the specific modules
+    # imported from hordelib depend on a package not included here, this will fail.
+    # See `build_helper.py` and `tests\meta\test_build_helper_import_check.py` for more information.
     - name: "🛠 Install pypa/build"
       if: ${{ steps.release.outputs.version != '' }}
       run: >-

--- a/build_helper.py
+++ b/build_helper.py
@@ -8,6 +8,9 @@ import subprocess
 from hordelib import install_comfy
 from hordelib.consts import COMFYUI_VERSION
 
+# NOTE If any imports to hordelib are added or changed, you must include those in
+# `tests/build/test_build_helper.py`
+
 
 def run(command):
     result = subprocess.run(command, shell=True, text=True)

--- a/build_helper.py
+++ b/build_helper.py
@@ -5,11 +5,11 @@ import os
 import shutil
 import subprocess
 
+# NOTE The following imports should *exactly* match those in `tests/meta/test_build_helper.py`
+# If `tests/meta/test_build_helper.py`, fails, include the imports missing in `release.yaml`.
+# and update [testenv:test-build-helper] in `tox.ini`.
 from hordelib import install_comfy
 from hordelib.consts import COMFYUI_VERSION
-
-# NOTE If any imports to hordelib are added or changed, you must include those in
-# `tests/build/test_build_helper.py`
 
 
 def run(command):

--- a/tests/meta/test_build_helper_import_check.py
+++ b/tests/meta/test_build_helper_import_check.py
@@ -1,0 +1,6 @@
+import sys
+
+
+def test_import_check():
+    from hordelib import install_comfy
+    from hordelib.consts import COMFYUI_VERSION

--- a/tests/meta/test_build_helper_import_check.py
+++ b/tests/meta/test_build_helper_import_check.py
@@ -2,5 +2,9 @@ import sys
 
 
 def test_import_check():
+    # NOTE These imports should *exactly* match any hordelib imports in build_helper.py
+    # If this test fails, include the imports missing in `release.yaml`.
+    # and update [testenv:test-build-helper] in `tox.ini`.
+
     from hordelib import install_comfy
     from hordelib.consts import COMFYUI_VERSION

--- a/tox.ini
+++ b/tox.ini
@@ -29,17 +29,10 @@ description = base evironment with all dependancies
 passenv =
     HORDELIB_TESTING
     AIWORKER_CACHE_HOME
-deps =
-    pytest>=7
-    pytest-sugar
-    pytest-cov
-    requests
-    -r requirements.txt
 
 [testenv:format]
 description = check formatting rules
 skip_install = true
-install_command = pip install
 deps =
     black==22.3.0
 commands = black --check .
@@ -47,7 +40,6 @@ commands = black --check .
 [testenv:lint]
 description = check all linting rules
 skip_install = true
-install_command = pip install
 deps =
     ruff==0.0.261
 commands = ruff .
@@ -55,7 +47,6 @@ commands = ruff .
 [testenv:lint-fix]
 description = fix all linting rules
 skip_install = true
-install_command = pip install
 deps =
     ruff==0.0.261
     black==22.3.0
@@ -68,7 +59,6 @@ commands =
 [testenv:lint-weak-check]
 description = check only certain few linting rules
 skip_install = true
-install_command = pip install
 deps =
     ruff==0.0.261
 commands = 
@@ -78,7 +68,6 @@ commands =
 [testenv:lint-weak-fix]
 description = fixes only certain few linting rules
 skip_install = true
-install_command = pip install
 deps =
     black==22.3.0
     ruff==0.0.261
@@ -88,7 +77,24 @@ commands =
     black .
     ruff --fix --select COM,I .
     python -c "print('*'*80 + '\n' + 'DEPRECATED: Favor using `tox -e lint-fix` for fixing linting issues.\n' + '*'*80)"
-    
+
+
+# NOTE: If you change this, also change the github workflow file 'release.yaml'
+# This test will fail if any imports build_helper directly relies on are not installed.
+# build_helper.py imports hordelib directly. See build_helper.py for more details.
+[testenv:test-build-helper]
+description = test build_helper.py under the same conditions as the github release workflow 
+skip_install = false
+deps = 
+    pytest>=7
+    build
+    loguru
+passenv =
+    HORDELIB_TESTING
+    AIWORKER_CACHE_HOME
+commands =
+     pytest tests/meta/build_helper_import_check.py
+
 [testenv:comfyui]
 description = run comfyui
 skip_install = true
@@ -102,5 +108,11 @@ install_command = pip install {opts} {packages}
 passenv =
     HORDELIB_TESTING
     AIWORKER_CACHE_HOME
+deps =
+    pytest>=7
+    pytest-sugar
+    pytest-cov
+    requests
+    -r requirements.txt
 commands =
-    pytest tests {posargs} --cov
+    pytest tests {posargs} --cov --ignore=tests/build_meta

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 env_list =
     format
     lint-weak-check
+    test-build-helper
     tests
 
 [coverage:run]
@@ -87,8 +88,8 @@ deps =
     build
     loguru
     typing-extensions
-    # NOTE: If you are here because this test fails, include the imports missing here *and* in 
-    # the appropriate place in `release.yaml`.
+    # NOTE: If you are here because this test fails, include the imports missing (check the exception thrown) 
+    # here *and* in the appropriate place in `release.yaml`.
     #
     # See also `build_helper.py`, and `.github/workflows/release.yaml` for more context.
 

--- a/tox.ini
+++ b/tox.ini
@@ -79,8 +79,6 @@ commands =
     python -c "print('*'*80 + '\n' + 'DEPRECATED: Favor using `tox -e lint-fix` for fixing linting issues.\n' + '*'*80)"
 
 
-# This test will fail if any imports build_helper directly relies on are not installed.
-# build_helper.py imports hordelib directly. See build_helper.py for more details.
 [testenv:test-build-helper]
 description = test build_helper.py under the same conditions as the github release workflow 
 skip_install = false
@@ -89,8 +87,10 @@ deps =
     build
     loguru
     typing-extensions
-    # NOTE: If this test fails, and you change any of these, you must also change the github workflow file 'release.yaml'
-    # or the release workflow *will* fail.
+    # NOTE: If you are here because this test fails, include the imports missing here *and* in 
+    # the appropriate place in `release.yaml`.
+    #
+    # See also `build_helper.py`, and `.github/workflows/release.yaml` for more context.
 
 passenv =
     HORDELIB_TESTING

--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ ignore_errors = True
 skip_empty = True
 
 [testenv]
-description = base evironment with all dependancies
+description = base evironment
 passenv =
     HORDELIB_TESTING
     AIWORKER_CACHE_HOME
@@ -79,7 +79,6 @@ commands =
     python -c "print('*'*80 + '\n' + 'DEPRECATED: Favor using `tox -e lint-fix` for fixing linting issues.\n' + '*'*80)"
 
 
-# NOTE: If you change this, also change the github workflow file 'release.yaml'
 # This test will fail if any imports build_helper directly relies on are not installed.
 # build_helper.py imports hordelib directly. See build_helper.py for more details.
 [testenv:test-build-helper]
@@ -89,11 +88,15 @@ deps =
     pytest>=7
     build
     loguru
+    typing-extensions
+    # NOTE: If this test fails, and you change any of these, you must also change the github workflow file 'release.yaml'
+    # or the release workflow *will* fail.
+
 passenv =
     HORDELIB_TESTING
     AIWORKER_CACHE_HOME
 commands =
-     pytest tests/meta/build_helper_import_check.py
+     pytest tests/meta/
 
 [testenv:comfyui]
 description = run comfyui
@@ -115,4 +118,4 @@ deps =
     requests
     -r requirements.txt
 commands =
-    pytest tests {posargs} --cov --ignore=tests/build_meta
+    pytest tests {posargs} --cov --ignore=tests/meta


### PR DESCRIPTION
Background: If any hordelib module referenced by `build_helper.py` had a new package dependency, the unit tests would pass locally and pass the CI, but would cause the release procedure to fail on the releases branch. 
- fix: This new unit test will cause the CI to fail before the unit tests are run, and is invoked when running just `tox`, or can be directly invoked with `tox -e test-build-helper`. See the changeset for more details on the implementation.
- fix: `tox.ini` is now configured to be closer to the official recommendations by their developers.
- build: Black is now enforced in the CI. (incidental, unrelated to build_helper.py)

tl;dr: Moving forward, if `test-build-helper` fails, make note of the missing import from the exception, and include it in the appropriate section of `tox.ini`, `tests\meta\test_build_helper_import_check.py`, and `.github\workflows\release.yml`. Inline comments to this effect point you to the other two places.