### PR TITLE
feat: ControlNet preload now possible, annotator disk location adjusted

### DIFF
--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -18,7 +18,7 @@ from hordelib.utils.logger import HordeLog
 def initialise(
     model_managers_to_load: dict[MODEL_CATEGORY_NAMES, bool] = DEFAULT_MODEL_MANAGERS,
     setup_logging=True,
-):
+):  # XXX # TODO Do we need `model_managers_to_load`?
     # Setup logging if requested
     HordeLog.initialise(setup_logging)
 

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -720,7 +720,7 @@ class BaseModelManager(ABC):
                 logger.init(f"{model}", status="Downloading")  # logger.init
                 self.download_model(model)
             else:
-                logger.init(f"{model} is already downloaded.")
+                logger.init(f"{model} is already downloaded.", status="Skipped")
         return True
 
     def check_model_available(self, model_name: str) -> bool:

--- a/hordelib/nodes/comfy_controlnet_preprocessors/leres/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/leres/__init__.py
@@ -2,7 +2,8 @@ import cv2
 import numpy as np
 import torch
 import os
-#from modules import devices, shared
+
+# from modules import devices, shared
 from torchvision.transforms import transforms
 
 # AdelaiDepth/LeReS imports
@@ -11,66 +12,73 @@ from .leres.multi_depth_model_woauxi import RelDepthModel
 from .leres.net_tools import strip_prefix_if_present
 
 # pix2pix/merge net imports
-#from .pix2pix.options.test_options import TestOptions
-#from .pix2pix.models.pix2pix4depth_model import Pix2Pix4DepthModel
+# from .pix2pix.options.test_options import TestOptions
+# from .pix2pix.models.pix2pix4depth_model import Pix2Pix4DepthModel
 
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path
-base_model_path = annotator_ckpts_path
+import builtins
+
 old_modeldir = os.path.dirname(os.path.realpath(__file__))
 import model_management
 
-remote_model_path_leres = "https://cloudstor.aarnet.edu.au/plus/s/lTIJF4vrvHCAI31/download"
+# remote_model_path_leres = "https://cloudstor.aarnet.edu.au/plus/s/lTIJF4vrvHCAI31/download"
+remote_model_path_leres = (
+    "https://huggingface.co/lllyasviel/Annotators/resolve/1e70a29f5d06c27d37988d2c6c43f6fd21fdb2d1/res101.pth"
+)
 remote_model_path_pix2pix = "https://sfu.ca/~yagiz/CVPR21/latest_net_G.pth"
 
 model = None
 pix2pixmodel = None
+
 
 def unload_leres_model():
     global model, pix2pixmodel
     if model is not None:
         model = model.cpu()
     if pix2pixmodel is not None:
-        pix2pixmodel = pix2pixmodel.unload_network('G')
+        pix2pixmodel = pix2pixmodel.unload_network("G")
+
 
 def download_model_if_not_existed():
-    model_path = os.path.join(base_model_path, "res101.pth")
-    #old_model_path = os.path.join(old_modeldir, "res101.pth")
-    
-    #if os.path.exists(old_model_path):
+    model_path = os.path.join(builtins.annotator_ckpts_path, "res101.pth")
+    # old_model_path = os.path.join(old_modeldir, "res101.pth")
+
+    # if os.path.exists(old_model_path):
     #    model_path = old_model_path
     if not os.path.exists(model_path):
         from comfy_controlnet_preprocessors.util import load_file_from_url
-        load_file_from_url(remote_model_path_leres, model_dir=base_model_path)
-        os.rename(os.path.join(base_model_path, 'download'), model_path)
+
+        load_file_from_url(remote_model_path_leres, model_dir=builtins.annotator_ckpts_path)
+        os.rename(os.path.join(builtins.annotator_ckpts_path, "download"), model_path)
     return model_path
+
 
 def apply_leres(input_image, thr_a, thr_b):
     global model, pix2pixmodel
-    #boost = shared.opts.data.get("control_net_monocular_depth_optim", False)
-    boost = False #Too lazy to implement this to ComfyUI
+    # boost = shared.opts.data.get("control_net_monocular_depth_optim", False)
+    boost = False  # Too lazy to implement this to ComfyUI
     if model is None:
         model_path = download_model_if_not_existed()
         checkpoint = torch.load(model_path, map_location=torch.device(model_management.get_torch_device()))
-        model = RelDepthModel(backbone='resnext101').to(model_management.get_torch_device())
-        model.load_state_dict(strip_prefix_if_present(checkpoint['depth_model'], "module."), strict=True)
+        model = RelDepthModel(backbone="resnext101").to(model_management.get_torch_device())
+        model.load_state_dict(strip_prefix_if_present(checkpoint["depth_model"], "module."), strict=True)
         del checkpoint
 
     """ if boost and pix2pixmodel is None:
-        pix2pixmodel_path = os.path.join(base_model_path, "latest_net_G.pth")
+        pix2pixmodel_path = os.path.join(builtins.annotator_ckpts_path, "latest_net_G.pth")
         if not os.path.exists(pix2pixmodel_path):
             from comfy_controlnet_preprocessors.util import load_file_from_url
-            load_file_from_url(remote_model_path_pix2pix, model_dir=base_model_path)
+            load_file_from_url(remote_model_path_pix2pix, model_dir=builtins.annotator_ckpts_path)
 
         opt = TestOptions().parse()
         if not torch.cuda.is_available():
             opt.gpu_ids = [] # cpu mode
         pix2pixmodel = Pix2Pix4DepthModel(opt)
-        pix2pixmodel.save_dir = base_model_path
+        pix2pixmodel.save_dir = builtins.annotator_ckpts_path
         pix2pixmodel.load_networks('latest')
         pix2pixmodel.eval() """
-    
-    #if devices.get_device_for("controlnet").type != 'mps':
-        #model = model.to(devices.get_device_for("controlnet"))
+
+    # if devices.get_device_for("controlnet").type != 'mps':
+    # model = model.to(devices.get_device_for("controlnet"))
 
     assert input_image.ndim == 3
     height, width, dim = input_image.shape
@@ -82,22 +90,22 @@ def apply_leres(input_image, thr_a, thr_b):
         else:
             depth = estimateleres(input_image, model, width, height)
 
-        numbytes=2
+        numbytes = 2
         depth_min = depth.min()
         depth_max = depth.max()
-        max_val = (2**(8*numbytes))-1
+        max_val = (2 ** (8 * numbytes)) - 1
 
         # check output before normalizing and mapping to 16 bit
         if depth_max - depth_min > np.finfo("float").eps:
             out = max_val * (depth - depth_min) / (depth_max - depth_min)
         else:
             out = np.zeros(depth.shape)
-        
+
         # single channel, 16 bit image
         depth_image = out.astype("uint16")
 
         # convert to uint8
-        depth_image = cv2.convertScaleAbs(depth_image, alpha=(255.0/65535.0))
+        depth_image = cv2.convertScaleAbs(depth_image, alpha=(255.0 / 65535.0))
 
         # remove near
         if thr_a != 0:

--- a/hordelib/nodes/comfy_controlnet_preprocessors/leres/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/leres/__init__.py
@@ -48,7 +48,7 @@ def download_model_if_not_existed():
         from comfy_controlnet_preprocessors.util import load_file_from_url
 
         load_file_from_url(remote_model_path_leres, model_dir=builtins.annotator_ckpts_path)
-        os.rename(os.path.join(builtins.annotator_ckpts_path, "download"), model_path)
+        os.rename(os.path.join(builtins.annotator_ckpts_path, "res101.pth"), model_path)
     return model_path
 
 

--- a/hordelib/nodes/comfy_controlnet_preprocessors/midas/api.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/midas/api.py
@@ -10,17 +10,19 @@ from .midas.dpt_depth import DPTDepthModel
 from .midas.midas_net import MidasNet
 from .midas.midas_net_custom import MidasNet_small
 from .midas.transforms import Resize, NormalizeImage, PrepareForNet
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path
+import builtins
 
 
 ISL_PATHS = {
-    "dpt_large": os.path.join(annotator_ckpts_path, "dpt_large-midas-2f21e586.pt"),
-    "dpt_hybrid": os.path.join(annotator_ckpts_path, "dpt_hybrid-midas-501f0c75.pt"),
+    "dpt_large": "dpt_large-midas-2f21e586.pt",
+    "dpt_hybrid": "dpt_hybrid-midas-501f0c75.pt",
     "midas_v21": "",
     "midas_v21_small": "",
 }
 
-remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/dpt_hybrid-midas-501f0c75.pt"
+remote_model_path = (
+    "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/dpt_hybrid-midas-501f0c75.pt"
+)
 
 
 def disabled_train(self, mode=True):
@@ -77,7 +79,7 @@ def load_midas_transform(model_type):
 def load_model(model_type):
     # https://github.com/isl-org/MiDaS/blob/master/run.py
     # load network
-    model_path = ISL_PATHS[model_type]
+    model_path = os.path.join(builtins.annotator_ckpts_path, ISL_PATHS[model_type])
     if model_type == "dpt_large":  # DPT-Large
         model = DPTDepthModel(
             path=model_path,
@@ -91,7 +93,8 @@ def load_model(model_type):
     elif model_type == "dpt_hybrid":  # DPT-Hybrid
         if not os.path.exists(model_path):
             from comfy_controlnet_preprocessors.util import load_file_from_url
-            load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
+
+            load_file_from_url(remote_model_path, model_dir=builtins.annotator_ckpts_path)
 
         model = DPTDepthModel(
             path=model_path,
@@ -106,18 +109,20 @@ def load_model(model_type):
         model = MidasNet(model_path, non_negative=True)
         net_w, net_h = 384, 384
         resize_mode = "upper_bound"
-        normalization = NormalizeImage(
-            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-        )
+        normalization = NormalizeImage(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 
     elif model_type == "midas_v21_small":
-        model = MidasNet_small(model_path, features=64, backbone="efficientnet_lite3", exportable=True,
-                               non_negative=True, blocks={'expand': True})
+        model = MidasNet_small(
+            model_path,
+            features=64,
+            backbone="efficientnet_lite3",
+            exportable=True,
+            non_negative=True,
+            blocks={"expand": True},
+        )
         net_w, net_h = 256, 256
         resize_mode = "upper_bound"
-        normalization = NormalizeImage(
-            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
-        )
+        normalization = NormalizeImage(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
 
     else:
         print(f"model_type '{model_type}' not implemented, use: --model_type large")
@@ -143,11 +148,7 @@ def load_model(model_type):
 
 
 class MiDaSInference(nn.Module):
-    MODEL_TYPES_TORCH_HUB = [
-        "DPT_Large",
-        "DPT_Hybrid",
-        "MiDaS_small"
-    ]
+    MODEL_TYPES_TORCH_HUB = ["DPT_Large", "DPT_Hybrid", "MiDaS_small"]
     MODEL_TYPES_ISL = [
         "dpt_large",
         "dpt_hybrid",
@@ -157,7 +158,7 @@ class MiDaSInference(nn.Module):
 
     def __init__(self, model_type):
         super().__init__()
-        assert (model_type in self.MODEL_TYPES_ISL)
+        assert model_type in self.MODEL_TYPES_ISL
         model, _ = load_model(model_type)
         self.model = model
         self.model.train = disabled_train
@@ -166,4 +167,3 @@ class MiDaSInference(nn.Module):
         with torch.no_grad():
             prediction = self.model(x)
         return prediction
-

--- a/hordelib/nodes/comfy_controlnet_preprocessors/mlsd/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/mlsd/__init__.py
@@ -8,7 +8,7 @@ from .models.mbv2_mlsd_tiny import MobileV2_MLSD_Tiny
 from .models.mbv2_mlsd_large import MobileV2_MLSD_Large
 from .utils import pred_lines
 
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path
+import builtins
 import model_management
 
 
@@ -17,10 +17,11 @@ remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/a
 
 class MLSDdetector:
     def __init__(self):
-        model_path = os.path.join(annotator_ckpts_path, "mlsd_large_512_fp32.pth")
+        model_path = os.path.join(builtins.annotator_ckpts_path, "mlsd_large_512_fp32.pth")
         if not os.path.exists(model_path):
             from comfy_controlnet_preprocessors.util import load_file_from_url
-            load_file_from_url(remote_model_path, model_dir=annotator_ckpts_path)
+
+            load_file_from_url(remote_model_path, model_dir=builtins.annotator_ckpts_path)
         model = MobileV2_MLSD_Large()
         model.load_state_dict(torch.load(model_path), strict=True)
         self.model = model.to(model_management.get_torch_device()).eval()

--- a/hordelib/nodes/comfy_controlnet_preprocessors/openpose/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/openpose/__init__.py
@@ -1,12 +1,13 @@
 import os
-os.environ["KMP_DUPLICATE_LIB_OK"]="TRUE"
+
+os.environ["KMP_DUPLICATE_LIB_OK"] = "TRUE"
 
 import torch
 import numpy as np
 from . import util
 from .body import Body
 from .hand import Hand
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path
+import builtins
 
 
 body_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/body_pose_model.pth"
@@ -15,13 +16,14 @@ hand_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/ann
 
 class OpenposeDetector:
     def __init__(self):
-        body_modelpath = os.path.join(annotator_ckpts_path, "body_pose_model.pth")
-        hand_modelpath = os.path.join(annotator_ckpts_path, "hand_pose_model.pth")
+        body_modelpath = os.path.join(builtins.annotator_ckpts_path, "body_pose_model.pth")
+        hand_modelpath = os.path.join(builtins.annotator_ckpts_path, "hand_pose_model.pth")
 
         if not os.path.exists(hand_modelpath):
             from comfy_controlnet_preprocessors.util import load_file_from_url
-            load_file_from_url(body_model_path, model_dir=annotator_ckpts_path)
-            load_file_from_url(hand_model_path, model_dir=annotator_ckpts_path)
+
+            load_file_from_url(body_model_path, model_dir=builtins.annotator_ckpts_path)
+            load_file_from_url(hand_model_path, model_dir=builtins.annotator_ckpts_path)
 
         self.body_estimation = Body(body_modelpath)
         self.hand_estimation = Hand(hand_modelpath)
@@ -36,7 +38,7 @@ class OpenposeDetector:
                 hands_list = util.handDetect(candidate, subset, oriImg)
                 all_hand_peaks = []
                 for x, y, w, is_left in hands_list:
-                    peaks = self.hand_estimation(oriImg[y:y+w, x:x+w, :])
+                    peaks = self.hand_estimation(oriImg[y : y + w, x : x + w, :])
                     peaks[:, 0] = np.where(peaks[:, 0] == 0, peaks[:, 0], peaks[:, 0] + x)
                     peaks[:, 1] = np.where(peaks[:, 1] == 0, peaks[:, 1], peaks[:, 1] + y)
                     all_hand_peaks.append(peaks)

--- a/hordelib/nodes/comfy_controlnet_preprocessors/pidinet/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/pidinet/__init__.py
@@ -3,26 +3,29 @@ import torch
 import numpy as np
 from einops import rearrange
 from .model import pidinet
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path, load_state_dict, load_file_from_url
+from comfy_controlnet_preprocessors.util import load_state_dict, load_file_from_url
+import builtins
 import model_management
 
 netNetwork = None
 remote_model_path = "https://huggingface.co/TencentARC/T2I-Adapter/resolve/main/third-party-models/table5_pidinet.pth"
-modeldir = os.path.join(annotator_ckpts_path, "pidinet")
+modeldir = "pidinet"
+
 
 def download_if_not_existed():
-    modelpath = os.path.join(modeldir, "table5_pidinet.pth")
+    modelpath = os.path.join(builtins.annotator_ckpts_path, modeldir, "table5_pidinet.pth")
     if not os.path.exists(modelpath):
         load_file_from_url(remote_model_path, model_dir=modeldir)
     return modelpath
+
 
 def apply_pidinet(input_image):
     global netNetwork
     if netNetwork is None:
         netNetwork = pidinet()
         ckp = load_state_dict(download_if_not_existed())
-        netNetwork.load_state_dict({k.replace('module.',''):v for k, v in ckp.items()})
-        
+        netNetwork.load_state_dict({k.replace("module.", ""): v for k, v in ckp.items()})
+
     netNetwork = netNetwork.to(model_management.get_torch_device())
     netNetwork.eval()
     assert input_image.ndim == 3
@@ -30,9 +33,9 @@ def apply_pidinet(input_image):
     with torch.no_grad():
         image_pidi = torch.from_numpy(input_image).float().to(model_management.get_torch_device())
         image_pidi = image_pidi / 255.0
-        image_pidi = rearrange(image_pidi, 'h w c -> 1 c h w')
+        image_pidi = rearrange(image_pidi, "h w c -> 1 c h w")
         edge = netNetwork(image_pidi)[-1]
-        edge = edge>0.5
+        edge = edge > 0.5
         edge = (edge * 255.0).clip(0, 255).cpu().numpy().astype(np.uint8)
-        
-    return edge[0][0] 
+
+    return edge[0][0]

--- a/hordelib/nodes/comfy_controlnet_preprocessors/uniformer/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/uniformer/__init__.py
@@ -2,7 +2,8 @@ import os
 
 from comfy_controlnet_preprocessors.uniformer.mmseg.apis import init_segmentor, inference_segmentor, show_result_pyplot
 from comfy_controlnet_preprocessors.uniformer.mmseg.core.evaluation import get_palette
-from comfy_controlnet_preprocessors.util import annotator_ckpts_path
+import builtins
+
 import model_management
 
 
@@ -11,14 +12,15 @@ checkpoint_file = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/ann
 
 class UniformerDetector:
     def __init__(self):
-        modelpath = os.path.join(annotator_ckpts_path, "upernet_global_small.pth")
+        modelpath = os.path.join(builtins.annotator_ckpts_path, "upernet_global_small.pth")
         if not os.path.exists(modelpath):
             from comfy_controlnet_preprocessors.util import load_file_from_url
-            load_file_from_url(checkpoint_file, model_dir=annotator_ckpts_path)
+
+            load_file_from_url(checkpoint_file, model_dir=builtins.annotator_ckpts_path)
         config_file = os.path.join(os.path.dirname(__file__), "exp", "upernet_global_small", "config.py")
         self.model = init_segmentor(config_file, modelpath).to(model_management.get_torch_device())
 
     def __call__(self, img):
         result = inference_segmentor(self.model, img)
-        res_img = show_result_pyplot(self.model, img, result, get_palette('ade'), opacity=1)
+        res_img = show_result_pyplot(self.model, img, result, get_palette("ade"), opacity=1)
         return res_img

--- a/hordelib/nodes/comfy_controlnet_preprocessors/util.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/util.py
@@ -8,8 +8,9 @@ from tqdm import tqdm
 from urllib.parse import urlparse
 import torch
 
+import builtins
 
-annotator_ckpts_path = os.path.join(os.path.dirname(__file__), "ckpts")
+builtins.annotator_ckpts_path = os.path.join(os.path.dirname(__file__), "ckpts")
 
 
 def HWC3(x):

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -1,0 +1,36 @@
+import requests
+from loguru import logger
+
+from hordelib.nodes.comfy_controlnet_preprocessors import canny, hed, leres, midas, mlsd, openpose, pidinet, uniformer
+
+annotator_model_integrity: dict[str, str] = {
+    "body_pose_model.pth": "25a948c16078b0f08e236bda51a385d855ef4c153598947c28c0d47ed94bb746",
+    "dpt_hybrid-midas-501f0c75.pt": "501f0c75b3bca7daec6b3682c5054c09b366765aef6fa3a09d03a5cb4b230853",
+    "hand_pose_model.pth": "b76b00d1750901abd07b9f9d8c98cc3385b8fe834a26d4b4f0aad439e75fc600",
+    "mlsd_large_512_fp32.pth": "5696f168eb2c30d4374bbfd45436f7415bb4d88da29bea97eea0101520fba082",
+    "network-bsds500.pth": "58a858782f5fa3e0ca3dc92e7a1a609add93987d77be3dfa54f8f8419d881a94",
+    "res101.pth": "1d696b2ef3e8336b057d0c15bc82d2fecef821bfebe5ef9d7671a5ec5dde520b",
+    "upernet_global_small.pth": "bebfa1264c10381e389d8065056baaadbdadee8ddc6e36770d1ec339dc84d970",
+}
+
+
+def download_all_controlnet_annotators() -> bool:
+    """Will start the download of all the models needed for the controlnet annotators."""
+    annotator_init_funcs = [
+        canny.CannyDetector,
+        hed.HEDdetector,
+        midas.MidasDetector,
+        mlsd.MLSDdetector,
+        openpose.OpenposeDetector,
+        uniformer.UniformerDetector,
+        leres.download_model_if_not_existed,
+        pidinet.download_if_not_existed,
+    ]
+
+    try:
+        for annotator_init_func in annotator_init_funcs:
+            annotator_init_func()
+        return True
+    except (OSError, requests.exceptions.RequestException) as e:
+        logger.init_err(f"Failed to download annotator: {e}")
+        return False

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -3,7 +3,7 @@ from loguru import logger
 
 from hordelib.nodes.comfy_controlnet_preprocessors import canny, hed, leres, midas, mlsd, openpose, pidinet, uniformer
 
-annotator_model_integrity: dict[str, str] = {
+ANNOTATOR_MODEL_SHA_LOOKUP: dict[str, str] = {
     "body_pose_model.pth": "25a948c16078b0f08e236bda51a385d855ef4c153598947c28c0d47ed94bb746",
     "dpt_hybrid-midas-501f0c75.pt": "501f0c75b3bca7daec6b3682c5054c09b366765aef6fa3a09d03a5cb4b230853",
     "hand_pose_model.pth": "b76b00d1750901abd07b9f9d8c98cc3385b8fe834a26d4b4f0aad439e75fc600",
@@ -12,6 +12,7 @@ annotator_model_integrity: dict[str, str] = {
     "res101.pth": "1d696b2ef3e8336b057d0c15bc82d2fecef821bfebe5ef9d7671a5ec5dde520b",
     "upernet_global_small.pth": "bebfa1264c10381e389d8065056baaadbdadee8ddc6e36770d1ec339dc84d970",
 }
+"""The annotator precomputed SHA hashes; the dict is in the form of `{"filename": "hash", ...}."""
 
 
 def download_all_controlnet_annotators() -> bool:
@@ -29,8 +30,10 @@ def download_all_controlnet_annotators() -> bool:
 
     try:
         for annotator_init_func in annotator_init_funcs:
+            logger.debug(f"Downloading annotator: {annotator_init_func}")
             annotator_init_func()
         return True
     except (OSError, requests.exceptions.RequestException) as e:
         logger.init_err(f"Failed to download annotator: {e}")
-        return False
+
+    return False

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -1,6 +1,10 @@
+import glob
+from pathlib import Path
+
 import requests
 from loguru import logger
 
+from hordelib.model_manager.base import BaseModelManager
 from hordelib.nodes.comfy_controlnet_preprocessors import canny, hed, leres, midas, mlsd, openpose, pidinet, uniformer
 
 ANNOTATOR_MODEL_SHA_LOOKUP: dict[str, str] = {
@@ -37,3 +41,35 @@ def download_all_controlnet_annotators() -> bool:
         logger.init_err(f"Failed to download annotator: {e}")
 
     return False
+
+
+def validate_all_controlnet_annotators(annotatorPath: Path) -> bool:
+    annotators = glob.glob("*.pt*", root_dir=annotatorPath)
+
+    for annotator in annotators:
+        annotator_full_path = annotatorPath.joinpath(annotator)
+
+        if annotator not in ANNOTATOR_MODEL_SHA_LOOKUP:
+            logger.init_warn(
+                f"Annotator file {annotator} is not in the model database. Ignoring...",
+                status="Warning",
+            )
+            logger.init_warn(f"File location: {annotator_full_path}", status="Warning")
+            continue
+
+        hash = BaseModelManager.get_file_sha256_hash(annotator_full_path)
+        if hash != ANNOTATOR_MODEL_SHA_LOOKUP[annotator]:
+            try:
+                annotator_full_path.unlink()
+                logger.init_err(
+                    f"Deleted annotator file {annotator} as it was corrupt.",
+                    status="Error",
+                )
+            except OSError:
+                logger.init_err(
+                    f"Annotator file {annotator} is corrupt. Please delete it and try again.",
+                    status="Error",
+                )
+                logger.init_err(f"File location: {annotator_full_path}", status="Error")
+            return False
+    return True

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -34,11 +34,11 @@ def download_all_controlnet_annotators() -> bool:
 
     try:
         for annotator_init_func in annotator_init_funcs:
-            logger.debug(f"Downloading annotator: {annotator_init_func}")
+            logger.init(f"Downloading annotator: {annotator_init_func}", status="Downloading")
             annotator_init_func()
         return True
     except (OSError, requests.exceptions.RequestException) as e:
-        logger.init_err(f"Failed to download annotator: {e}")
+        logger.init_err(f"Failed to download annotator: {e}", status="Error")
 
     return False
 

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -1,9 +1,13 @@
 # shared_model_manager.py
 import builtins
+import glob
 from pathlib import Path
-from hordelib.model_manager.hyper import ModelManager
+
+from loguru import logger
+
 from hordelib.cache import get_cache_directory
-from hordelib.preload import download_all_controlnet_annotators
+from hordelib.model_manager.hyper import ModelManager
+from hordelib.preload import annotator_model_integrity, download_all_controlnet_annotators
 
 
 class SharedModelManager:
@@ -36,9 +40,59 @@ class SharedModelManager:
         args_passed.pop("cls")  # XXX This is temporary
 
         cls.manager.init_model_managers(**args_passed)
-        builtins.annotator_ckpts_path = Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
-        # XXX # FIXME _PLEASE_
 
     @classmethod
-    def preloadAnnotators(cls):
-        download_all_controlnet_annotators()
+    def preloadAnnotators(cls) -> bool:
+        """Attempt to preload all annotators. If they are downloaded, this will only ensure the SHA256 integrity.
+
+        Raises:
+            RuntimeError: Occurs if loadModelManagers() has not yet been called when invoking this method.
+
+        Returns:
+            bool: If the annotators are downloaded and the integrity is OK, this will return True. Otherwise, false.
+        """
+        if cls.manager is None:
+            raise RuntimeError("ModelManager not initialized. Please call loadModelManagers() first.")
+        if cls.manager.controlnet is None:
+            raise RuntimeError(
+                (
+                    "ControlNet not initialized. "
+                    " Please call loadModelManagers() first and specify loading ControlNet."
+                ),
+            )
+
+        builtins.annotator_ckpts_path = (
+            Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator").joinpath("ckpts")
+        )
+        # XXX # FIXME _PLEASE_
+        # XXX The hope here is that this will be temporary, until comfy officially releases support for annotators.
+
+        logger.debug(f"WORKAROUND: Setting `builtins.annotator_ckpts_path` to: {builtins.annotator_ckpts_path}")
+
+        annotators_OK = download_all_controlnet_annotators()
+        if not annotators_OK:
+            logger.init_err("Failed to download one or more annotators.", status="Error")
+            return False
+
+        # We're doing this here because the effort involved in getting these annotators into the model managers
+        # is non-trivial, and likely will be made obsolete by comfy implementing this functionality natively.
+        annotatorCacheDir = Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
+        annotators = glob.glob("*.pt*", root_dir=annotatorCacheDir)
+        for annotator in annotators:
+            annotator_full_path = Path(annotatorCacheDir.joinpath(annotator))
+            hash = cls.manager.controlnet.get_file_sha256_hash(annotator_full_path)
+            if hash != annotator_model_integrity[annotator]:
+                try:
+                    annotator_full_path.unlink()
+                    logger.init_err(
+                        f"Deleted annotator file {annotator} as it was corrupt.",
+                        status="Error",
+                    )
+                except OSError:
+                    logger.init_err(
+                        f"Annotator file {annotator} is corrupt. Please delete it and try again.",
+                        status="Error",
+                    )
+                    logger.init_err(f"File location: {annotatorCacheDir}", status="Error")
+                return False
+        return True

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -7,7 +7,11 @@ from loguru import logger
 
 from hordelib.cache import get_cache_directory
 from hordelib.model_manager.hyper import BaseModelManager, ModelManager
-from hordelib.preload import ANNOTATOR_MODEL_SHA_LOOKUP, download_all_controlnet_annotators
+from hordelib.preload import (
+    ANNOTATOR_MODEL_SHA_LOOKUP,
+    download_all_controlnet_annotators,
+    validate_all_controlnet_annotators,
+)
 
 
 class SharedModelManager:
@@ -41,12 +45,9 @@ class SharedModelManager:
 
         cls.manager.init_model_managers(**args_passed)
 
-    @classmethod
-    def preloadAnnotators(cls) -> bool:
+    @staticmethod
+    def preloadAnnotators() -> bool:
         """Preload all annotators. If they are already downloaded, this will only ensure the SHA256 integrity.
-
-        Raises:
-            RuntimeError: Occurs if loadModelManagers() has not yet been called when invoking this method.
 
         Returns:
             bool: If the annotators are downloaded and the integrity is OK, this will return True. Otherwise, false.
@@ -54,7 +55,9 @@ class SharedModelManager:
         annotators_in_legacy_directory = Path(builtins.annotator_ckpts_path).glob("*.pt*")
 
         for legacy_annotator in annotators_in_legacy_directory:
-            logger.warning(f"Annotator found in legacy directory. This file can be safely deleted: {legacy_annotator}")
+            logger.init_warn("Annotator found in legacy directory. This file can be safely deleted:", status="Warning")
+            logger.init_warn(f"{legacy_annotator}", status="Warning")
+            logger.init_warn("", status="Warning")
 
         builtins.annotator_ckpts_path = (
             Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator").joinpath("ckpts")
@@ -66,28 +69,22 @@ class SharedModelManager:
 
         logger.debug(f"WORKAROUND: Setting `builtins.annotator_ckpts_path` to: {builtins.annotator_ckpts_path}")
 
+        # If any annotators are downloaded, check those for SHA integrity first.
+        # if any get purged (incomplete download), then we will be able to recover
+        # by downloading them below.
+        validate_all_controlnet_annotators(builtins.annotator_ckpts_path)
+
+        logger.init("Attempting to preload all controlnet annotators.", status="Loading")
+        logger.init("This may take several minutes...", status="Loading")
+
         annotators_downloaded_successfully = download_all_controlnet_annotators()
         if not annotators_downloaded_successfully:
             logger.init_err("Failed to download one or more annotators.", status="Error")
             return False
 
-        annotatorCacheDir = Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
-        annotators = glob.glob("*.pt*", root_dir=annotatorCacheDir)
-        for annotator in annotators:
-            annotator_full_path = annotatorCacheDir.joinpath(annotator)
-            hash = BaseModelManager.get_file_sha256_hash(annotator_full_path)
-            if hash != ANNOTATOR_MODEL_SHA_LOOKUP[annotator]:
-                try:
-                    annotator_full_path.unlink()
-                    logger.init_err(
-                        f"Deleted annotator file {annotator} as it was corrupt.",
-                        status="Error",
-                    )
-                except OSError:
-                    logger.init_err(
-                        f"Annotator file {annotator} is corrupt. Please delete it and try again.",
-                        status="Error",
-                    )
-                    logger.init_err(f"File location: {annotatorCacheDir}", status="Error")
-                return False
+        annotators_all_validated_successfully = validate_all_controlnet_annotators(builtins.annotator_ckpts_path)
+        if not annotators_all_validated_successfully:
+            logger.init_err("Failed to validate one or more annotators.", status="Error")
+            return False
+
         return True

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -1,6 +1,9 @@
 # shared_model_manager.py
-
+import builtins
+from pathlib import Path
 from hordelib.model_manager.hyper import ModelManager
+from hordelib.cache import get_cache_directory
+from hordelib.preload import download_all_controlnet_annotators
 
 
 class SharedModelManager:
@@ -33,3 +36,9 @@ class SharedModelManager:
         args_passed.pop("cls")  # XXX This is temporary
 
         cls.manager.init_model_managers(**args_passed)
+        builtins.annotator_ckpts_path = Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
+        # XXX # FIXME _PLEASE_
+
+    @classmethod
+    def preloadAnnotators(cls):
+        download_all_controlnet_annotators()

--- a/tests/model_managers/test_annotators.py
+++ b/tests/model_managers/test_annotators.py
@@ -1,0 +1,26 @@
+import glob
+import pathlib
+
+import pytest
+from PIL import Image
+
+
+class TestHordePreloadAnnotators:
+    def test_preload_annotators(self):
+        import hordelib
+
+        hordelib.initialise({}, True)
+
+        from hordelib.shared_model_manager import SharedModelManager
+
+        SharedModelManager.preloadAnnotators()
+
+    def test_check_sha_annotators(self):
+        from hordelib.cache import get_cache_directory
+        from hordelib.model_manager.base import BaseModelManager
+
+        annotatorCacheDir = pathlib.Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
+        annotators = glob.glob("*.pt*", root_dir=annotatorCacheDir)
+        for annotator in annotators:
+            hash = BaseModelManager.get_file_sha256_hash(annotatorCacheDir.joinpath(annotator))
+            print(f"{annotator}: {hash}")  # XXX # TODO Validate hashes

--- a/tests/test_horde_controlnet_annotator.py
+++ b/tests/test_horde_controlnet_annotator.py
@@ -27,6 +27,7 @@ class TestHordeInference:
         assert SharedModelManager.manager is not None
         for preproc in HordeLib.CONTROLNET_IMAGE_PREPROCESSOR_MAP.keys():
             SharedModelManager.manager.controlnet.download_control_type(preproc)
+        assert SharedModelManager.preloadAnnotators()
         self.image = Image.open("images/test_annotator.jpg")
         self.width, self.height = self.image.size
         yield

--- a/tests/test_shared_model_manager.py
+++ b/tests/test_shared_model_manager.py
@@ -109,13 +109,6 @@ class TestSharedModelManager:
                     model_manager.get_file_sha256_hash(f"{model_manager.modelFolderPath}/{path}")
         pass
 
-    def test_check_sha_annotators(self):
-        annotatorCacheDir = pathlib.Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
-        annotators = glob.glob("*.pt*", root_dir=annotatorCacheDir)
-        for annotator in annotators:
-            hash = SharedModelManager.manager.controlnet.get_file_sha256_hash(annotatorCacheDir.joinpath(annotator))
-            print(f"{annotator}: {hash}")
-
     def test_check_validate_all_available_models(self):
         assert SharedModelManager.manager is not None
         for model_manager in SharedModelManager.manager.active_model_managers:

--- a/tests/test_shared_model_manager.py
+++ b/tests/test_shared_model_manager.py
@@ -1,6 +1,10 @@
 # test_horde.py
+import glob
+import pathlib
+
 import pytest
 
+from hordelib.cache import get_cache_directory
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 
@@ -105,8 +109,18 @@ class TestSharedModelManager:
                     model_manager.get_file_sha256_hash(f"{model_manager.modelFolderPath}/{path}")
         pass
 
+    def test_check_sha_annotators(self):
+        annotatorCacheDir = pathlib.Path(get_cache_directory()).joinpath("controlnet").joinpath("annotator")
+        annotators = glob.glob("*.pt*", root_dir=annotatorCacheDir)
+        for annotator in annotators:
+            hash = SharedModelManager.manager.controlnet.get_file_sha256_hash(annotatorCacheDir.joinpath(annotator))
+            print(f"{annotator}: {hash}")
+
     def test_check_validate_all_available_models(self):
         assert SharedModelManager.manager is not None
         for model_manager in SharedModelManager.manager.active_model_managers:
             for model in model_manager.available_models:
                 assert model_manager.validate_model(model)
+
+    def test_preload_annotators(self):
+        assert SharedModelManager.preloadAnnotators()


### PR DESCRIPTION
- `SharedModelManager.preloadAnnotators()` will now:
  - attempt to download all controlnet annotators to `AIWORKER_CACHE_HOME`.
  - if downloaded, verify the SHA integrity
  - if either fails, `preloadAnnotators()` returns false
