### PR TITLE
fix: Incorrect annotator download location, confusing logging message

### DIFF
--- a/hordelib/nodes/comfy_controlnet_preprocessors/pidinet/__init__.py
+++ b/hordelib/nodes/comfy_controlnet_preprocessors/pidinet/__init__.py
@@ -15,7 +15,7 @@ modeldir = "pidinet"
 def download_if_not_existed():
     modelpath = os.path.join(builtins.annotator_ckpts_path, modeldir, "table5_pidinet.pth")
     if not os.path.exists(modelpath):
-        load_file_from_url(remote_model_path, model_dir=modeldir)
+        load_file_from_url(remote_model_path, model_dir=modelpath)
     return modelpath
 
 

--- a/hordelib/preload.py
+++ b/hordelib/preload.py
@@ -33,8 +33,8 @@ def download_all_controlnet_annotators() -> bool:
     ]
 
     try:
+        logger.init("Downloading annotators if required...", status="Checking")
         for annotator_init_func in annotator_init_funcs:
-            logger.init(f"Downloading annotator: {annotator_init_func}", status="Downloading")
             annotator_init_func()
         return True
     except (OSError, requests.exceptions.RequestException) as e:


### PR DESCRIPTION
- fix: pidinet would sneak into the runtime working directory
  - `AI-Horde-Worker/pidinet/table5_pidinet.pth` can be safely deleted.
- fix: The logging message that the annotators was being 'downloaded' was misleading, in reality these models (if already downloaded) are just being validated. The logging message has been clarified to this end.