### PR TITLE
feat: encode prompt pipeline in raw output image metadata

### DIFF
--- a/hordelib/nodes/node_image_output.py
+++ b/hordelib/nodes/node_image_output.py
@@ -25,6 +25,11 @@ class HordeImageOutput:
 
     CATEGORY = "image"
 
+    def _json_hack(self, obj):
+        if hasattr(obj, "__class__"):
+            return f"{obj.__class__.__name__} instance"
+        return f"Object of type {type(obj).__name__}"
+
     def get_image(self, images, prompt=None, extra_pnginfo=None):
         results = []
         for image in images:
@@ -33,12 +38,11 @@ class HordeImageOutput:
             img = Image.fromarray(np.clip(i, 0, 255).astype(np.uint8))
             metadata = PngInfo()
             # Save the full pipeline and variables into the PNG metadata
-            # FIXME we don't have a model manager JSON serialiser
-            # if prompt is not None:
-            #     metadata.add_text("prompt", json.dumps(prompt))
-            # if extra_pnginfo is not None:
-            #     for x in extra_pnginfo:
-            #         metadata.add_text(x, json.dumps(extra_pnginfo[x]))
+            if prompt is not None:
+                metadata.add_text("prompt", json.dumps(prompt, default=self._json_hack))
+            if extra_pnginfo is not None:
+                for x in extra_pnginfo:
+                    metadata.add_text(x, json.dumps(extra_pnginfo[x], default=self._json_hack))
 
             byte_stream = BytesIO()
             img.save(byte_stream, format="PNG", pnginfo=metadata, compress_level=4)

--- a/tests/test_image_metadata.py
+++ b/tests/test_image_metadata.py
@@ -1,0 +1,54 @@
+# test_horde.py
+import json
+
+import pytest
+from PIL import Image
+
+from hordelib.horde import HordeLib
+from hordelib.shared_model_manager import SharedModelManager
+
+
+class TestHordeInference:
+    @pytest.fixture(autouse=True, scope="class")
+    def setup_and_teardown(self):
+        TestHordeInference.horde = HordeLib()
+
+        TestHordeInference.default_model_manager_args = {
+            "compvis": True,
+        }
+        SharedModelManager.loadModelManagers(**self.default_model_manager_args)
+        assert SharedModelManager.manager is not None
+        SharedModelManager.manager.load("Deliberate")
+        yield
+        del TestHordeInference.horde
+        SharedModelManager._instance = None
+        SharedModelManager.manager = None
+
+    def test_text_to_image(self):
+        data = {
+            "sampler_name": "k_dpmpp_2m",
+            "cfg_scale": 7.5,
+            "denoising_strength": 1.0,
+            "seed": 123456789,
+            "height": 512,
+            "width": 512,
+            "karras": True,
+            "tiling": False,
+            "hires_fix": False,
+            "clip_skip": 1,
+            "control_type": None,
+            "image_is_control": False,
+            "return_control_map": False,
+            "prompt": "a secret metadata store",
+            "ddim_steps": 25,
+            "n_iter": 1,
+            "model": "Deliberate",
+        }
+        assert self.horde is not None
+        png_data = self.horde.basic_inference(data, rawpng=True)
+        assert png_data is not None
+        image = Image.open(png_data)
+        metadata = image.info
+        assert "prompt" in metadata
+        info = json.loads(metadata["prompt"])
+        assert info["prompt"]["inputs"]["text"] == "a secret metadata store"


### PR DESCRIPTION
The entire input pipeline along with all it's variables is saved into the output image PNG metadata.

This is in the raw PNG bytesteam data only, the horde turns this into webp which currently loses this metadata. But this works for local hordelib use if saving PNGs directly.