### PR TITLE
fix: exclude `build/` folder from linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,12 +70,13 @@ exclude = '''
   | \.tox
   | comfy_controlnet_preprocessors
   | facerestore
+  | build
 )/
 ''' # If you change this, you probably need to also change [tool.mypy] below
 
 [tool.ruff] # XXX this isn't part of CI yet
 line-length=119
-exclude=["comfy_controlnet_preprocessors", "facerestore"]
+exclude=["comfy_controlnet_preprocessors", "facerestore", "build"]
 ignore=[
     "F401", # imported but unused
     "E402", # Module level import not at top of file


### PR DESCRIPTION
This may be a placebo change, but it shouldn't harm anything either.