### PR TITLE
feat: horde_model_reference added, re-enable github hosted model reference

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -18,6 +18,11 @@ class HordeSupportedBackends(Enum):
     ComfyUI = auto()
 
 
+# Models Excluded from hordelib (for now) # FIXME
+# this could easily be a json file on the AI-Horde-image-model-reference repo
+EXCLUDED_MODEL_NAMES = ["Ether Real Mix", "pix2pix", "anything_v4_inpainting", "dreamlike_diffusion_inpainting"]
+
+
 class MODEL_CATEGORY_NAMES(str, Enum):
     """Look up str enum for the categories of models (compvis, controlnet, clip, etc...)."""
 

--- a/hordelib/initialisation.py
+++ b/hordelib/initialisation.py
@@ -20,9 +20,11 @@ _is_initialised = False
 
 
 def initialise(
-    model_managers_to_load: dict[MODEL_CATEGORY_NAMES, bool] = DEFAULT_MODEL_MANAGERS,
+    # model_managers_to_load: dict[MODEL_CATEGORY_NAMES, bool] = DEFAULT_MODEL_MANAGERS,
+    *,
     setup_logging=True,
     clear_logs=False,
+    debug_logging=False,
 ):  # XXX # TODO Do we need `model_managers_to_load`?
 
     global _is_initialised
@@ -32,7 +34,10 @@ def initialise(
         shutil.rmtree("./logs")
 
     # Setup logging if requested
-    HordeLog.initialise(setup_logging)
+    HordeLog.initialise(setup_logging=setup_logging)
+    if debug_logging:
+        HordeLog.set_logger_verbosity(5)
+        HordeLog.quiesce_logger(0)
 
     # If developer mode, don't permit some things
     if not RELEASE_VERSION and " " in get_hordelib_path():

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -267,7 +267,7 @@ class BaseModelManager(ABC):
                 logger.error(f"{model_name} not found")
                 return False
             if not local and model_name not in self.available_models:
-                logger.error(f"{model_name} not available")
+                logger.init_warn(f"{model_name} may need to be downloaded, checking...", status="Loading")
                 download_succeeded = self.download_model(model_name)
                 if not download_succeeded:
                     logger.init_err(f"{model_name} failed to download", status="Error")

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -5,7 +5,7 @@ import threading
 import torch
 from loguru import logger
 
-from hordelib.consts import MODEL_CATEGORY_NAMES
+from hordelib.consts import MODEL_CATEGORY_NAMES, EXCLUDED_MODEL_NAMES
 
 # from hordelib.model_manager.aitemplate import AITemplateModelManager
 from hordelib.model_manager.base import BaseModelManager
@@ -350,6 +350,13 @@ class ModelManager:
         Returns:
             bool | None: The success of the load. If `None`, the model was not found.
         """
+        if model_name in EXCLUDED_MODEL_NAMES:
+            logger.init_warn(
+                f"{model_name} is excluded from loading at this time. If this is unexpected, let us know on discord.",
+                status="Skipping",
+            )
+            return False
+
         if not self.cuda_available:
             cpu_only = True
 

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -5,7 +5,7 @@ import threading
 import torch
 from loguru import logger
 
-from hordelib.consts import MODEL_CATEGORY_NAMES, EXCLUDED_MODEL_NAMES
+from hordelib.consts import EXCLUDED_MODEL_NAMES, MODEL_CATEGORY_NAMES
 
 # from hordelib.model_manager.aitemplate import AITemplateModelManager
 from hordelib.model_manager.base import BaseModelManager

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -3,9 +3,13 @@ import builtins
 import glob
 from pathlib import Path
 
+from horde_model_reference.legacy.download_live_legacy_dbs import download_all_models as download_live_legacy_dbs
+from horde_model_reference.meta_consts import MODEL_REFERENCE_CATEGORIES
+from horde_model_reference.path_consts import get_model_reference_filename
 from loguru import logger
 
 from hordelib.cache import get_cache_directory
+from hordelib.config_path import get_hordelib_path
 from hordelib.model_manager.hyper import BaseModelManager, ModelManager
 from hordelib.preload import (
     ANNOTATOR_MODEL_SHA_LOOKUP,
@@ -42,7 +46,27 @@ class SharedModelManager:
 
         args_passed = locals().copy()  # XXX This is temporary
         args_passed.pop("cls")  # XXX This is temporary
-
+        logger.debug(f"Redownloading all model databases to {get_hordelib_path()}.")
+        db_reference_files_lookup = download_live_legacy_dbs(override_existing=True)
+        for model_db, file_path in db_reference_files_lookup.items():
+            hordelib_model_db_path = get_model_reference_filename(
+                model_db,
+                base_path=Path(get_hordelib_path()).joinpath("model_database"),
+            )
+            try:
+                logger.debug(f"Unlinking {hordelib_model_db_path} if it exists.")
+                hordelib_model_db_path.unlink()
+                hordelib_model_db_path.hardlink_to(file_path)
+            except OSError as e:
+                logger.init_error(
+                    f"Failed to hard link {file_path} to {hordelib_model_db_path}.",
+                    status="Error",
+                )
+                logger.init_error(
+                    "If you continue to get the error, please delete the file and try again.",
+                    status="Error",
+                )
+                raise e
         cls.manager.init_model_managers(**args_passed)
 
     @staticmethod

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # Add this in for tox, comment out for build
 --extra-index-url https://download.pytorch.org/whl/cu118
+horde_model_reference
+pydantic
 torch>=2.0.0
 xformers>=0.0.19
 torchvision

--- a/tests/model_managers/test_annotators.py
+++ b/tests/model_managers/test_annotators.py
@@ -9,7 +9,7 @@ class TestHordePreloadAnnotators:
     def test_preload_annotators(self):
         import hordelib
 
-        hordelib.initialise({}, True)
+        hordelib.initialise(setup_logging=True)
 
         from hordelib.shared_model_manager import SharedModelManager
 

--- a/tests/model_managers/test_comvis.py
+++ b/tests/model_managers/test_comvis.py
@@ -10,7 +10,7 @@ class TestCompvis:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         if not self._initialised:
-            hordelib.initialise({consts.MODEL_CATEGORY_NAMES.compvis: True})
+            hordelib.initialise()
         from hordelib.model_manager.compvis import CompVisModelManager
 
         self.compvis_model_manager = CompVisModelManager()

--- a/tests/model_managers/test_diffusers.py
+++ b/tests/model_managers/test_diffusers.py
@@ -10,7 +10,7 @@ class TestDiffusers:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         if not self._initialised:
-            hordelib.initialise({consts.MODEL_CATEGORY_NAMES.diffusers: True})
+            hordelib.initialise()
         from hordelib.model_manager.diffusers import DiffusersModelManager
 
         self.diffusers_model_manager = DiffusersModelManager()

--- a/tests/test_shared_model_manager.py
+++ b/tests/test_shared_model_manager.py
@@ -7,6 +7,7 @@ import pytest
 from hordelib.cache import get_cache_directory
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
+from hordelib.utils.logger import HordeLog
 
 
 class TestSharedModelManager:
@@ -16,6 +17,9 @@ class TestSharedModelManager:
     @pytest.fixture(autouse=True)
     def setup_and_teardown(self):
         self.horde = HordeLib()
+        HordeLog.initialise(True)
+        HordeLog.set_logger_verbosity(5)
+        HordeLog.quiesce_logger(0)
 
         self.default_model_manager_args = {  # XXX # TODO
             # aitemplate
@@ -98,6 +102,12 @@ class TestSharedModelManager:
         assert SharedModelManager.manager.is_model_loaded("GFPGAN") is True
         assert SharedModelManager.manager.is_model_loaded("RealESRGAN_x4plus") is True
         assert SharedModelManager.manager.is_model_loaded("4x_NMKD_Superscale_SP") is True
+
+    def test_safetensor_loading(self):
+        assert SharedModelManager.manager is not None
+        assert SharedModelManager.manager.is_model_loaded("Ether Real Mix") is False
+        SharedModelManager.manager.load("Ether Real Mix")
+        assert SharedModelManager.manager.is_model_loaded("Ether Real Mix") is True
 
     def test_check_sha(self):
         """Check the sha256 hashes of all models. If the .sha file doesn't exist, this will write it out."""

--- a/tests/test_shared_model_manager.py
+++ b/tests/test_shared_model_manager.py
@@ -5,6 +5,7 @@ import pathlib
 import pytest
 
 from hordelib.cache import get_cache_directory
+from hordelib.consts import EXCLUDED_MODEL_NAMES
 from hordelib.horde import HordeLib
 from hordelib.shared_model_manager import SharedModelManager
 from hordelib.utils.logger import HordeLog
@@ -103,11 +104,10 @@ class TestSharedModelManager:
         assert SharedModelManager.manager.is_model_loaded("RealESRGAN_x4plus") is True
         assert SharedModelManager.manager.is_model_loaded("4x_NMKD_Superscale_SP") is True
 
-    def test_safetensor_loading(self):
+    def test_model_excluding(self):
         assert SharedModelManager.manager is not None
-        assert SharedModelManager.manager.is_model_loaded("Ether Real Mix") is False
-        SharedModelManager.manager.load("Ether Real Mix")
-        assert SharedModelManager.manager.is_model_loaded("Ether Real Mix") is True
+        for excluded_model in EXCLUDED_MODEL_NAMES:
+            assert not SharedModelManager.manager.load(excluded_model)
 
     def test_check_sha(self):
         """Check the sha256 hashes of all models. If the .sha file doesn't exist, this will write it out."""


### PR DESCRIPTION
- This is the first baby step towards relying on horde_model_reference ([pypi](https://pypi.org/project/horde-model-reference/), [temporary github repo](https://github.com/tazlin/AI-Horde-image-model-reference)).
- The database is now updated on each startup from [the legacy repo](https://github.com/db0/AI-Horde-image-model-reference).
  - The schema will be quietly converted to a new format within horde_model_reference under the hood, but will remain fully reliant on the existence of the legacy repo for the time being.
- Any updates to the stable_diffusion.json file should be validated and normalized using :
```python
python -m horde_model_reference.legacy.validate path/to/stable_diffusion.json --write file/to/write_out_to.json
```