### PR TITLE
fix: prevents vscode/pytest discovery from executing test code prematurely

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,0 @@
-import hordelib
-
-# Remove any command line args passed to pytest. ComfyUI hates
-# the pytest args being in argv, we we hack them out purely for testing.
-hordelib.initialise()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+import hordelib
+
+
+@pytest.fixture(scope="session", autouse=True)
+def session_fixture():
+    hordelib.initialise()


### PR DESCRIPTION
Any time pytest discovery would occur, `hordelib.initialise()` would run. This is very problematic for contributors wishing to use VSCode, which would automatically run discovery *every save of any file*, potentially causing side effects and more often than not, heartache.