### PR TITLE
When gathering loaded/available names, allows filtering by model manager type

### DIFF
--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -365,15 +365,15 @@ class ModelManager:
         return None
 
     def get_mm_pointers(self, mm_types: list[str] | None = None):
+        mm_pointers = set()
         if not mm_types:
-            return []
+            return mm_pointers
         # If any value in the list is not a string, we assume it's a mm pointer already but we verify
-        mm_pointers = []
         if any(type(mm_type) != str for mm_type in mm_types):
             for mm_type in mm_types:
                 for active_mm in self.active_model_managers:
                     if active_mm == mm_type:
-                        mm_pointers.append(active_mm)
+                        mm_pointers.add(active_mm)
                         break
         for mm_type in mm_types:
             if type(mm_type) != str:
@@ -384,6 +384,6 @@ class ModelManager:
                 logger.warning(f"Exception when looking up model manager '{mm_type}': {err}")
             for active_mm in self.active_model_managers:
                 if type(active_mm) == mm_type:
-                    mm_pointers.append(active_mm)
+                    mm_pointers.add(active_mm)
                     break
         return mm_pointers

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -58,21 +58,35 @@ class ModelManager:
             _models.update(model_manager.model_reference)
         return _models
 
-    @property
-    def available_models(self) -> list[str]:
+    def get_available_models(self, mm_include=None, mm_exclude=None) -> list[str]:
         """All models for which information exists, and for which a download attempt could be made."""
         all_available_models: list[str] = []
+        mm_include = self.get_mm_pointers(mm_include)
+        mm_exclude = self.get_mm_pointers(mm_exclude)
         for model_manager in self.active_model_managers:
+            if mm_include and model_manager not in mm_include:
+                continue
+            if mm_exclude and model_manager in mm_exclude:
+                continue
             all_available_models.extend(model_manager.available_models)
         return all_available_models
 
-    @property
-    def loaded_models(self) -> dict[str, dict]:
+    available_models = property(get_available_models)
+
+    def get_loaded_models(self, mm_include=None, mm_exclude=None) -> dict[str, dict]:
         """All models for which have successfully loaded across all `BaseModelManager` types."""
         all_loaded_models: dict[str, dict] = {}
+        mm_include = self.get_mm_pointers(mm_include)
+        mm_exclude = self.get_mm_pointers(mm_exclude)
         for model_manager in self.active_model_managers:
+            if mm_include and model_manager not in mm_include:
+                continue
+            if mm_exclude and model_manager in mm_exclude:
+                continue
             all_loaded_models.update(model_manager.get_loaded_models())
         return all_loaded_models
+
+    loaded_models = property(get_loaded_models)
 
     @property
     def active_model_managers(self) -> list[BaseModelManager]:
@@ -268,53 +282,29 @@ class ModelManager:
                 return model_manager.move_from_disk_cache(model_name, model, clip, vae)
         return None
 
-    def get_loaded_models_names(self) -> list:
-        """DEPRECATED: Use property self.loaded_models. Returns a list of all the currently loaded models.
-
+    def get_loaded_models_names(
+        self, mm_include: list[str] | None = None, mm_exclude: list[str] | None = None,
+    ) -> list:
+        """
         Returns:
             list: All currently loaded models.
         """
-        return list(self.loaded_models.keys())
+        loaded_models = self.get_loaded_models(mm_include, mm_exclude)
+        return list(loaded_models.keys())
 
     def is_model_loaded(self, model_name) -> bool:
         return model_name in self.loaded_models
 
-    def get_available_models_by_types(self, model_types: list[str] | None = None):
-        if not model_types:
-            model_types = ["ckpt", "diffusers"]
-        models_available = []
-        for model_type in model_types:
-            if model_type == "ckpt" and self.compvis is not None:
-                for model in self.compvis.model_reference:
-                    # We don't want to check the .yaml file as those exist in this repo instead
-                    model_files = [
-                        filename
-                        for filename in self.compvis.get_model_files(model)
-                        if not filename["path"].endswith(".yaml")
-                    ]
-                    if self.compvis.check_available(model_files):
-                        models_available.append(model)
-            if model_type == "diffusers" and self.diffusers is not None:
-                for model in self.diffusers.model_reference:
-                    if self.diffusers.check_available(
-                        self.diffusers.get_model_files(model),
-                    ):
-                        models_available.append(model)
-        return models_available
+    def get_available_models_by_types(self, mm_include: list[str] | None = None, mm_exclude: list[str] | None = None):
+        if not mm_include and not mm_exclude:
+            mm_include = ["ckpt", "diffusers"]
+        return self.get_available_models(mm_include, mm_exclude)
 
     def count_available_models_by_types(
         self,
         model_types: list[str] | None = None,
     ) -> int:
         return len(self.get_available_models_by_types(model_types))
-
-    def get_available_models(self) -> list:
-        """Returns a list of all available models.
-
-        Returns:
-            list: All available models.
-        """
-        return self.available_models
 
     def ensure_memory_available(self, specific_type: type[BaseModelManager] | None = None) -> None:
         """Asserts minimum amount of RAM is available. Unloads models if necessary."""
@@ -371,3 +361,21 @@ class ModelManager:
 
         logger.error(f"{model_name} not found")
         return None
+
+    def get_mm_pointers(self, mm_types: list[str] | None = None):
+        if not mm_types:
+            return []
+        # If any value in the list is not a string, we assume it's a mm pointer already
+        if not any(type(mm_type) == str for mm_type in mm_types):
+            return mm_types
+        mm_pointers = []
+        for mm_type in mm_types:
+            try:
+                mm_type = MODEL_MANAGERS_TYPE_LOOKUP[MODEL_CATEGORY_NAMES(mm_type)]
+                for active_mm in self.active_model_managers:
+                    if type(active_mm) == mm_type:
+                        mm_pointers.append(active_mm)
+                        break
+            except Exception as err:
+                logger.warning(err)
+        return mm_pointers

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -367,17 +367,23 @@ class ModelManager:
     def get_mm_pointers(self, mm_types: list[str] | None = None):
         if not mm_types:
             return []
-        # If any value in the list is not a string, we assume it's a mm pointer already
-        if not any(type(mm_type) == str for mm_type in mm_types):
-            return mm_types
+        # If any value in the list is not a string, we assume it's a mm pointer already but we verify
         mm_pointers = []
-        for mm_type in mm_types:
-            try:
-                mm_type = MODEL_MANAGERS_TYPE_LOOKUP[MODEL_CATEGORY_NAMES(mm_type)]
+        if any(type(mm_type) != str for mm_type in mm_types):
+            for mm_type in mm_types:
                 for active_mm in self.active_model_managers:
-                    if type(active_mm) == mm_type:
+                    if active_mm == mm_type:
                         mm_pointers.append(active_mm)
                         break
+        for mm_type in mm_types:
+            if type(mm_type) != str:
+                continue
+            try:
+                mm_type = MODEL_MANAGERS_TYPE_LOOKUP[MODEL_CATEGORY_NAMES(mm_type)]
             except Exception as err:
-                logger.warning(err)
+                logger.warning(f"Exception when looking up model manager '{mm_type}': {err}")
+            for active_mm in self.active_model_managers:
+                if type(active_mm) == mm_type:
+                    mm_pointers.append(active_mm)
+                    break
         return mm_pointers

--- a/hordelib/model_manager/hyper.py
+++ b/hordelib/model_manager/hyper.py
@@ -283,7 +283,9 @@ class ModelManager:
         return None
 
     def get_loaded_models_names(
-        self, mm_include: list[str] | None = None, mm_exclude: list[str] | None = None,
+        self,
+        mm_include: list[str] | None = None,
+        mm_exclude: list[str] | None = None,
     ) -> list:
         """
         Returns:

--- a/tests/model_managers/test_hyper.py
+++ b/tests/model_managers/test_hyper.py
@@ -1,0 +1,72 @@
+# test_horde.py
+import pytest
+from PIL import Image
+
+from hordelib.horde import HordeLib
+from hordelib.shared_model_manager import SharedModelManager
+
+
+class TestHyperMM:
+    @pytest.fixture(autouse=True, scope="class")
+    def setup_and_teardown(self):
+        TestHyperMM.horde = HordeLib()
+
+        SharedModelManager.loadModelManagers(
+            compvis=True,
+            blip=True,
+            clip=True,
+            safety_checker=True,
+            esrgan=True,
+        )
+        assert SharedModelManager.manager is not None
+        SharedModelManager.manager.load("RealESRGAN_x4plus")
+        SharedModelManager.manager.load("Deliberate")
+        SharedModelManager.manager.load("safety_checker")
+        yield
+        del TestHyperMM.horde
+        SharedModelManager._instance = None
+        SharedModelManager.manager = None
+
+    def test_get_loaded_models_names(self):
+        assert "RealESRGAN_x4plus" in SharedModelManager.manager.get_loaded_models_names()
+        assert "Deliberate" in SharedModelManager.manager.get_loaded_models_names()
+        assert "safety_checker" in SharedModelManager.manager.get_loaded_models_names()
+        assert "Deliberate" in SharedModelManager.manager.get_loaded_models_names(mm_include=["compvis"])
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_loaded_models_names(mm_include=["compvis"])
+        assert "safety_checker" not in SharedModelManager.manager.get_loaded_models_names(mm_include=["compvis"])
+        assert "Deliberate" in SharedModelManager.manager.get_loaded_models_names(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_loaded_models_names(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "safety_checker" in SharedModelManager.manager.get_loaded_models_names(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "Deliberate" in SharedModelManager.manager.get_loaded_models_names(mm_exclude=["esrgan"])
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_loaded_models_names(mm_exclude=["esrgan"])
+        assert "safety_checker" in SharedModelManager.manager.get_loaded_models_names(mm_exclude=["esrgan"])
+
+    def test_get_available_models_by_types(self):
+        assert "RealESRGAN_x4plus" in SharedModelManager.manager.get_available_models_by_types()
+        assert "Deliberate" in SharedModelManager.manager.get_available_models_by_types()
+        assert "safety_checker" in SharedModelManager.manager.get_available_models_by_types()
+        assert "Deliberate" in SharedModelManager.manager.get_available_models_by_types(mm_include=["compvis"])
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_available_models_by_types(
+            mm_include=["compvis"],
+        )
+        assert "safety_checker" not in SharedModelManager.manager.get_available_models_by_types(mm_include=["compvis"])
+        assert "Deliberate" in SharedModelManager.manager.get_available_models_by_types(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_available_models_by_types(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "safety_checker" in SharedModelManager.manager.get_available_models_by_types(
+            mm_include=["compvis", "safety_checker"],
+        )
+        assert "Deliberate" in SharedModelManager.manager.get_available_models_by_types(mm_exclude=["esrgan"])
+        assert "RealESRGAN_x4plus" not in SharedModelManager.manager.get_available_models_by_types(
+            mm_exclude=["esrgan"],
+        )
+        assert "safety_checker" in SharedModelManager.manager.get_available_models_by_types(mm_exclude=["esrgan"])

--- a/tests/model_managers/test_hyper.py
+++ b/tests/model_managers/test_hyper.py
@@ -70,3 +70,17 @@ class TestHyperMM:
             mm_exclude=["esrgan"],
         )
         assert "safety_checker" in SharedModelManager.manager.get_available_models_by_types(mm_exclude=["esrgan"])
+
+    def test_get_mm_pointers(self):
+        print(SharedModelManager.manager.get_mm_pointers(["compvis"]))
+        assert SharedModelManager.manager.get_mm_pointers(["compvis"]) == [SharedModelManager.manager.compvis]
+        # because gfpgan MM not active
+        assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "gfpgan"])) == 1
+        assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "gfpgan", "esrgan"])) == 2
+        assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "FAKE"])) == 1
+        assert SharedModelManager.manager.get_mm_pointers(None) == []
+        # Any value other than a string or a mm pointer is ignored
+        assert SharedModelManager.manager.get_mm_pointers([None]) == []
+        assert SharedModelManager.manager.get_mm_pointers(
+            [None, SharedModelManager.manager.compvis, "FAKE", "esrgan"]
+        ) == [SharedModelManager.manager.compvis, SharedModelManager.manager.esrgan]

--- a/tests/model_managers/test_hyper.py
+++ b/tests/model_managers/test_hyper.py
@@ -73,14 +73,14 @@ class TestHyperMM:
 
     def test_get_mm_pointers(self):
         print(SharedModelManager.manager.get_mm_pointers(["compvis"]))
-        assert SharedModelManager.manager.get_mm_pointers(["compvis"]) == [SharedModelManager.manager.compvis]
+        assert SharedModelManager.manager.get_mm_pointers(["compvis"]) == {SharedModelManager.manager.compvis}
         # because gfpgan MM not active
         assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "gfpgan"])) == 1
         assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "gfpgan", "esrgan"])) == 2
         assert len(SharedModelManager.manager.get_mm_pointers(["compvis", "FAKE"])) == 1
-        assert SharedModelManager.manager.get_mm_pointers(None) == []
+        assert SharedModelManager.manager.get_mm_pointers(None) == set()
         # Any value other than a string or a mm pointer is ignored
-        assert SharedModelManager.manager.get_mm_pointers([None]) == []
+        assert SharedModelManager.manager.get_mm_pointers([None]) == set()
         assert SharedModelManager.manager.get_mm_pointers(
-            [None, SharedModelManager.manager.compvis, "FAKE", "esrgan"]
-        ) == [SharedModelManager.manager.compvis, SharedModelManager.manager.esrgan]
+            [None, SharedModelManager.manager.compvis, "FAKE", "esrgan", "compvis"],
+        ) == {SharedModelManager.manager.compvis, SharedModelManager.manager.esrgan}


### PR DESCRIPTION
In hyper:

* Adjusted `get_loaded_models_names()` so that I can exclude or include specific model managers
* Adjusted `get_available_models_by_types()` likewise
* Created  getter `get_loaded_models()` to allow for include/excludes. 
* Created getter `get_available_models()` to allow for include/excludes
* Created `get_mm_pointers()` to convert mm enum strings, to pointers for active MMs.
* Added tests.

