### PR TITLE
feat: Support prepending proxy URL to github model reference json downloads

### DIFF
--- a/hordelib/consts.py
+++ b/hordelib/consts.py
@@ -7,6 +7,8 @@ from hordelib.config_path import get_hordelib_path
 COMFYUI_VERSION = "84ea21c815d426000c233e0c7b8c542764335cc8"
 """The exact version of ComfyUI version to load."""
 
+REMOTE_PROXY = ""
+
 REMOTE_MODEL_DB = "https://raw.githubusercontent.com/db0/AI-Horde-image-model-reference/main/"
 """The default base endpoint where to find model databases. See MODEL_DB_NAMES for valid database names."""
 

--- a/hordelib/model_manager/base.py
+++ b/hordelib/model_manager/base.py
@@ -545,7 +545,7 @@ class BaseModelManager(ABC):
         with open(file_name, "rb") as file_to_check:
             file_hash = hashlib.md5()
             while True:
-                chunk = file_to_check.read(8192)  # Changed just because it broke pylint
+                chunk = file_to_check.read(2**20)  # Changed just because it broke pylint
                 if not chunk:
                     break
                 file_hash.update(chunk)
@@ -582,7 +582,7 @@ class BaseModelManager(ABC):
         with open(file_name, "rb") as file_to_check:
             file_hash = hashlib.sha256()
             while True:
-                chunk = file_to_check.read(8192)
+                chunk = file_to_check.read(2**20)
                 if not chunk:
                     break
                 file_hash.update(chunk)
@@ -678,7 +678,7 @@ class BaseModelManager(ABC):
                 total=int(response.headers.get("content-length", 0)),
                 disable=UserSettings.disable_download_progress.active,
             ) as pbar:
-                for chunk in response.iter_content(chunk_size=16 * 1024):
+                for chunk in response.iter_content(chunk_size=1024 * 1024 * 10):
                     response.raise_for_status()
                     if chunk:
                         f.write(chunk)

--- a/hordelib/shared_model_manager.py
+++ b/hordelib/shared_model_manager.py
@@ -10,6 +10,7 @@ from loguru import logger
 
 from hordelib.cache import get_cache_directory
 from hordelib.config_path import get_hordelib_path
+from hordelib.consts import REMOTE_PROXY
 from hordelib.model_manager.hyper import BaseModelManager, ModelManager
 from hordelib.preload import (
     ANNOTATOR_MODEL_SHA_LOOKUP,
@@ -47,7 +48,7 @@ class SharedModelManager:
         args_passed = locals().copy()  # XXX This is temporary
         args_passed.pop("cls")  # XXX This is temporary
         logger.debug(f"Redownloading all model databases to {get_hordelib_path()}.")
-        db_reference_files_lookup = download_live_legacy_dbs(override_existing=True)
+        db_reference_files_lookup = download_live_legacy_dbs(override_existing=True, proxy_url=REMOTE_PROXY)
         for model_db, file_path in db_reference_files_lookup.items():
             hordelib_model_db_path = get_model_reference_filename(
                 model_db,


### PR DESCRIPTION
Users which live in countries where github is blocked are unable to run workers due to github being blocked. This allows users to set `REMOTE_PROXY` in `hordelib/consts.py` (and possibly in the worker config soon) to circumvent this by prepending a fixed url, such as to a proxy.

This change was made possible here: https://github.com/Haidra-Org/horde-model-reference/commit/d92d4a0b1ca8ac79076fdf9d6bbce7054c751fcd.

Also includes a potential speed up with reading/writing downloads and calculating SHA hashes from @Cubox. 