### PR TITLE
ci: fix: allow release workflow repo write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - releases
+      
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
An attempt to fix without incurring a security concern on all actions on the repo.